### PR TITLE
fix(): allow shorthands with 4 values

### DIFF
--- a/style/config/.scss-lint.yml
+++ b/style/config/.scss-lint.yml
@@ -162,7 +162,7 @@ linters:
 
   Shorthand:
     enabled: true
-    allowed_shorthands: [1, 2]
+    allowed_shorthands: [1, 2, 4]
 
   SingleLinePerProperty:
     enabled: true


### PR DESCRIPTION
This was expected to work like this but was wrongly configured. Currently it does not allow for shorthands like:

```css
margin: 4px 5px 3px 10px;
```