### PR TITLE
Disable Metrics/ParameterLists

### DIFF
--- a/style/config/.rubocop.yml
+++ b/style/config/.rubocop.yml
@@ -509,7 +509,7 @@ Metrics/MethodLength:
 Metrics/ParameterLists:
   Description: Avoid long parameter lists.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#too-many-params
-  Enabled: true
+  Enabled: false
   Max: 5
   CountKeywordArgs: true
 Metrics/PerceivedComplexity:


### PR DESCRIPTION
Ruby ahora soporta **keyword arguments**, con lo cual no es tan raro tener algo como:

`def foo(_amount = nil, field: nil, fixed: false, factor: 1, modifier: :none, missing: 1)`

Entiendo que esta regla se aplique a:

`def foo(_amount, _field, _fixed, _factor, _modifier, _missing)`

Pero entorpece el uso del los **keyword arguments**...