### PR TITLE
fix(): remove unnecesary rule

### DIFF
--- a/style/config/tslint.json
+++ b/style/config/tslint.json
@@ -69,7 +69,6 @@
     "no-trailing-whitespace": true,
     "no-unreachable": true,
     "no-unused-expression": true,
-    "no-unused-new": true,
     "no-unused-variable": [
       true
     ],


### PR DESCRIPTION
no-unused-new does not exist and was crashing vscode (https://github.com/Microsoft/vscode-tslint/issues/66)