### PR TITLE
use `!` insdead of `not`

### DIFF
--- a/style/config/.rubocop.yml
+++ b/style/config/.rubocop.yml
@@ -779,7 +779,7 @@ Style/NilComparison:
 Style/Not:
   Description: Use ! instead of not.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#bang-not-not
-  Enabled: false
+  Enabled: true
 Style/OneLineConditional:
   Description: Favor the ternary operator(?:) over if/then/else/end constructs.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator


### PR DESCRIPTION
Enable `Style/Not` cop to force the use of `!` instead of `not`

Esto nace de la conversacion en este PR
https://github.com/platanus/amigosecreto-rails/pull/79#pullrequestreview-7545856