### PR TITLE
feat(rubocop): disable Metrics/BlockLength

### DIFF
--- a/style/config/.rubocop.yml
+++ b/style/config/.rubocop.yml
@@ -53,6 +53,8 @@ Style/BarePercentLiterals:
   SupportedStyles:
   - percent_q
   - bare_percent
+Metrics/BlockLength:
+  Enabled: false
 Style/BracesAroundHashParameters:
   Description: Enforce braces style around hash parameters.
   Enabled: true


### PR DESCRIPTION
Me pasó esto:
<img width="539" alt="screen shot 2016-12-10 at 12 40 05 pm" src="https://cloud.githubusercontent.com/assets/3026413/21074376/0cd11ee0-bed6-11e6-9ea7-2487641c7694.png">
Se queja de que los bloques tienen muchas líneas. Me parece que esto no tiene sentido porque cuando el bloque está dentro de un método, se queja también `Metrics/MethodLength` y cuando el bloque está fuera de un método generalmente lo usamos en DSLs y estos suelen ser bloques de definición con muchas líneas. Como es el caso de los `describe` de Rspec.

> @blackjid Creo que esto me empezó a pasar cuando instalé Rubocop 0.45