### PR TITLE
Proposals

### DIFF
--- a/code/ruby.md
+++ b/code/ruby.md
@@ -4,7 +4,7 @@
 
 La version actual que usamos se puede ver en el [stack ruby](https://github.com/platanus/our-boxen/blob/HEAD/modules/stacks/manifests/ruby.pp) de boxen
 
-Para administrar las versiones de ruby usamos [rbnev](https://github.com/sstephenson/rbenv)
+Para administrar las versiones de ruby usamos [rbenv](https://github.com/sstephenson/rbenv)
 
 Los proyectos deben tener la version de ruby definida en el archivo
 `.ruby-version` en la raíz del proyecto. Debemos definir versiones

--- a/style/config/.eslintrc.json
+++ b/style/config/.eslintrc.json
@@ -29,7 +29,7 @@
     "dot-notation": [1, {
       "allowKeywords": true
     }],
-    "dot-location": [2, "object"],
+    "dot-location": [2, "property"],
     "eqeqeq": [2],
     "guard-for-in": 2,
     "no-alert": 1,


### PR DESCRIPTION
This pull request includes 

- a fix for a typo `s/rbnev/rbenv/`
- changes to .eslintrc `dot-location` rule to use dot on properties instead of object.

This is because I find way easier to read:

```javascript
http.get(url)
.then(function(){}
```
than:

```javascript
http.get(url).
then(function(){}
```

:+1: 