### PR TITLE
feat(git): add rules for commit contexts and a commit example

### DIFF
--- a/tools/git.md
+++ b/tools/git.md
@@ -29,11 +29,16 @@ El tipo nos ayuda a clasificar los commits. Los tipos que usamos son:
 
 #### Contexto
 
-  El contexto es una palabra que haga referencia al lugar del código donde afecta el commit.
+El contexto es una palabra que hace referencia al lugar del código o funcionalidad que afecta el commit. Debe escribirse usando `kebab-case`, por ejemplo: `user-signup`
+
+De manera opcional, se puede agregar información sobre el componente específico del código afectado. Si se agrega esta información:
+
+  * Debe ir después del contexto, separado usando un punto (`.`). Por ejemplo: `api.LoginService`
+  * El nombre del componente modificado debe estar en el mismo formato en el que aparece en el código (por ejemplo en `CamelCase` si es una clase ruby).
 
 #### Descripción
 
-  * usamos el verbo imperativo en inglés:  "change" not "changed" nor "changes"
+  * usamos el verbo imperativo en inglés:  "change" no "changed" ni "changes"
   * sin mayúscula al principio
   * sin punto (.) al final
 
@@ -42,3 +47,15 @@ Nota: Esto es un extracto/traducción de [este documento](https://github.com/ang
 ### Branches y Pull-requests
 
 Salvo cosas muy insignificantes, los features los hacemos en un nuevo branch y hacemos un pull-request hacia master.
+
+### Ejemplo
+
+Como ejemplo de estas recomendaciones el siguiente commit soluciona un bug en el componente/clase `SignUpForm` del frontend de una aplicación, en el cual no se estaba entregando feedback de la validación sobre si el nombre de usuario estaba disponible o no:
+
+```
+fix(ui.SignUpForm): validate username availability
+
+The `SignUpForm` component wasn´t validating the availability of the `username` field and only displayed a `couldn´t create account` error on submit.
+
+This commit adds an asynchronous validation when typing on the field so the user will know if the username is available before completing further fields.
+```

--- a/tools/git.md
+++ b/tools/git.md
@@ -33,12 +33,13 @@ El contexto es una palabra que hace referencia al lugar del código o funcionali
 
 De manera opcional, se puede agregar información sobre el componente específico del código afectado. Si se agrega esta información:
 
-  * Debe ir después del contexto, separado usando un punto (`.`). Por ejemplo: `api.LoginService`
+  * Debe ir después del contexto, separado usando un slash (`/`). Por ejemplo: `api/LoginService`
   * El nombre del componente modificado debe estar en el mismo formato en el que aparece en el código (por ejemplo en `CamelCase` si es una clase ruby).
 
 #### Descripción
 
   * usamos el verbo imperativo en inglés:  "change" no "changed" ni "changes"
+  * separado por un espacio del contexto
   * sin mayúscula al principio
   * sin punto (.) al final
 
@@ -53,7 +54,7 @@ Salvo cosas muy insignificantes, los features los hacemos en un nuevo branch y h
 Como ejemplo de estas recomendaciones el siguiente commit soluciona un bug en el componente/clase `SignUpForm` del frontend de una aplicación, en el cual no se estaba entregando feedback de la validación sobre si el nombre de usuario estaba disponible o no:
 
 ```
-fix(ui.SignUpForm): validate username availability
+fix(ui/SignUpForm): validate username availability
 
 The `SignUpForm` component wasn´t validating the availability of the `username` field and only displayed a `couldn´t create account` error on submit.
 

--- a/tools/git.md
+++ b/tools/git.md
@@ -9,7 +9,7 @@ Los mensajes de commit:
   * normalmente tienen una sola línea (aunque sabemos que más podría ser mejor)
   * la primera línea se forma de un **tipo**, un **contexto** y una **descripción**
     ```
-    tipo(contexto):descripción
+    tipo(contexto): descripción
     ```
 
   La línea no debiera tener más de 100 caracteres para que se lea bien en Github.


### PR DESCRIPTION
# Git context

Este PR agrega reglas para la parte de "contexto" de los mensajes de commit y un ejemplo de las mismas reglas.

## Raciocinio

Sobre todo cuando se trabaja en una pieza de software grande que incorpora más de un sistema (por ejemplo una app rail con el frontend SPA en el mismo repo) es muy útil agregar mas información al contexto para saber específicamente qué parte del código se modificó.

La propuesta es que los mensajes de commits sean de la siguiente forma:

```
type(context.component):message
        ^         ^
        |         Nombre tal cual aparece en el código el componente afectado (opcional)
        |   
 Subsistema o funcionalidad que implementa o afecta el commit
         
```

La idea es que el `context` se escriba usando `kebab-case` y se separe del `component` usando un punto, entendiendo que en la gran mayoría de los lenguajes modernos de programación es el operador punto `.` el que se utiliza para especificar dentro de una jerarquía.