### PR TITLE
style(eslintrc): set max line length to 120 chars

### DIFF
--- a/style/config/.eslintrc.json
+++ b/style/config/.eslintrc.json
@@ -243,7 +243,7 @@
     "linebreak-style": [2, "unix"],
     "lines-around-comment": 0,
     "max-depth": [2, 4],
-    "max-len": [0],
+    "max-len": [2, 120],
     "max-nested-callbacks": [2, 4],
     "max-params": [1, 4],
     "max-statements": [1, 10],


### PR DESCRIPTION
120 caracteres para mantener el estilo que tiene nuestro `tslint.json`