### PR TITLE
Fix rubocop 0.65

### DIFF
--- a/style/config/.rubocop.yml
+++ b/style/config/.rubocop.yml
@@ -1,8 +1,4 @@
 AllCops:
-  Include:
-  - "**/*.rake"
-  - "**/Gemfile"
-  - "**/Rakefile"
   Exclude:
   - "vendor/**/*"
   - "db/**/*"

--- a/style/config/.rubocop.yml
+++ b/style/config/.rubocop.yml
@@ -708,7 +708,7 @@ Style/EvenOdd:
   Description: Favor the use of Fixnum#even? && Fixnum#odd?
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#predicate-methods
   Enabled: false
-Style/FlipFlop:
+Lint/FlipFlop:
   Description: Checks for flip flops
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-flip-flops
   Enabled: false

--- a/style/config/.rubocop.yml
+++ b/style/config/.rubocop.yml
@@ -6,6 +6,8 @@ AllCops:
   DisplayCopNames: false
   StyleGuideCopsOnly: false
   TargetRubyVersion: 2.5
+Rails:
+  Enabled: true
 Layout/AccessModifierIndentation:
   Description: Check indentation of private/protected visibility modifiers.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected


### PR DESCRIPTION
## Descripción

 - Había una regla que se me pasó actualizar (`Style/FlipFlop` -> `Lint/FlipFlop`)
 - Probablemente el mono no estaba funcionando porque en algún momento cambiaron el comportamiento de la herencia de las configuraciones y al hacer `Include` se estaban excluyendo todos los archivos que no estaban ahí (https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#inheritance)