### PR TITLE
chore(rubocop): replace redundant rules

### DIFF
--- a/style/config/.rubocop.yml
+++ b/style/config/.rubocop.yml
@@ -8,25 +8,6 @@ AllCops:
   TargetRubyVersion: 2.5
 Rails:
   Enabled: true
-Layout/AccessModifierIndentation:
-  Description: Check indentation of private/protected visibility modifiers.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected
-  Enabled: true
-  EnforcedStyle: indent
-  SupportedStyles:
-  - outdent
-  - indent
-Layout/AlignHash:
-  Description: Align the elements of a hash literal if they span more than one line.
-  Enabled: true
-  EnforcedHashRocketStyle: key
-  EnforcedColonStyle: key
-  EnforcedLastArgumentHashStyle: always_inspect
-  SupportedLastArgumentHashStyles:
-  - always_inspect
-  - always_ignore
-  - ignore_implicit
-  - ignore_explicit
 Layout/AlignParameters:
   Description: Align the parameters of a method call if they span more than one line.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-double-indent
@@ -35,41 +16,8 @@ Layout/AlignParameters:
   SupportedStyles:
   - with_first_parameter
   - with_fixed_indentation
-Style/AndOr:
-  Description: Use &&/|| instead of and/or.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-and-or-or
-  Enabled: true
-  EnforcedStyle: always
-  SupportedStyles:
-  - always
-  - conditionals
-Style/BarePercentLiterals:
-  Description: Checks if usage of %() or %Q() matches configuration.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-q-shorthand
-  Enabled: true
-  EnforcedStyle: bare_percent
-  SupportedStyles:
-  - percent_q
-  - bare_percent
 Metrics/BlockLength:
   Enabled: false
-Style/BracesAroundHashParameters:
-  Description: Enforce braces style around hash parameters.
-  Enabled: true
-  EnforcedStyle: no_braces
-  SupportedStyles:
-  - braces
-  - no_braces
-  - context_dependent
-Layout/CaseIndentation:
-  Description: Indentation of when in a case/when/[else/]end.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-when-to-case
-  Enabled: true
-  EnforcedStyle: case
-  SupportedStyles:
-  - case
-  - end
-  IndentOneStep: false
 Style/ClassAndModuleChildren:
   Description: Checks style of children classes and modules.
   Enabled: false
@@ -77,24 +25,6 @@ Style/ClassAndModuleChildren:
   SupportedStyles:
   - nested
   - compact
-Style/ClassCheck:
-  Description: Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
-  Enabled: true
-  EnforcedStyle: is_a?
-  SupportedStyles:
-  - is_a?
-  - kind_of?
-Style/CollectionMethods:
-  Description: Preferred collection methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size
-  Enabled: false
-  PreferredMethods:
-    collect: map
-    collect!: map!
-    inject: reduce
-    detect: find
-    find_all: select
-    find: detect
 Style/CommentAnnotation:
   Description: Checks formatting of special comments (TODO, FIXME, OPTIMIZE, HACK,
     REVIEW).
@@ -106,26 +36,6 @@ Style/CommentAnnotation:
   - OPTIMIZE
   - HACK
   - REVIEW
-Layout/DotPosition:
-  Description: Checks the position of the dot in multi-line method calls.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
-  Enabled: true
-  EnforcedStyle: leading
-  SupportedStyles:
-  - leading
-  - trailing
-Layout/EmptyLineBetweenDefs:
-  Description: Use empty lines between defs.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods
-  Enabled: true
-  AllowAdjacentOneLineDefs: false
-Layout/EmptyLinesAroundBlockBody:
-  Description: Keeps track of empty lines around block bodies.
-  Enabled: true
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
 Layout/EmptyLinesAroundClassBody:
   Description: Keeps track of empty lines around class bodies.
   Enabled: true
@@ -140,31 +50,11 @@ Layout/EmptyLinesAroundModuleBody:
   SupportedStyles:
   - empty_lines
   - no_empty_lines
-Style/Encoding:
-  Description: Use UTF-8 as the source file encoding.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#utf-8
-  Enabled: true
 Naming/FileName:
   Description: Use snake_case for source file names.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
   Enabled: false
   Exclude: []
-Layout/FirstParameterIndentation:
-  Description: Checks the indentation of the first parameter in a method call.
-  Enabled: true
-  EnforcedStyle: special_for_inner_method_call_in_parentheses
-  SupportedStyles:
-  - consistent
-  - special_for_inner_method_call
-  - special_for_inner_method_call_in_parentheses
-Style/For:
-  Description: Checks use of for or each in multiline loops.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-for-loops
-  Enabled: true
-  EnforcedStyle: each
-  SupportedStyles:
-  - for
-  - each
 Style/FormatString:
   Description: Enforce the use of Kernel#sprintf, Kernel#format or String#%.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#sprintf
@@ -186,31 +76,10 @@ Style/GuardClause:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
   Enabled: false
   MinBodyLength: 1
-Style/HashSyntax:
-  Description: 'Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax { :a =>
-    1, :b => 2 }.'
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-literals
-  Enabled: true
-  EnforcedStyle: ruby19
-  SupportedStyles:
-  - ruby19
-  - hash_rockets
 Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: false
-Layout/IndentationWidth:
-  Description: Use 2 spaces for indentation.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
-  Enabled: true
-  Width: 2
-Layout/IndentHash:
-  Description: Checks the indentation of the first key in a hash literal.
-  Enabled: true
-  EnforcedStyle: special_inside_parentheses
-  SupportedStyles:
-  - special_inside_parentheses
-  - consistent
 Style/LambdaCall:
   Description: Use lambda.call(...) instead of lambda.(...).
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#proc-call
@@ -228,27 +97,6 @@ Style/Next:
   SupportedStyles:
   - skip_modifier_ifs
   - always
-Style/NonNilCheck:
-  Description: Checks for redundant nil checks.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-non-nil-checks
-  Enabled: true
-  IncludeSemanticChanges: false
-Style/MethodDefParentheses:
-  Description: Checks if the method definitions have or don't have parentheses.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#method-parens
-  Enabled: true
-  EnforcedStyle: require_parentheses
-  SupportedStyles:
-  - require_parentheses
-  - require_no_parentheses
-Naming/MethodName:
-  Description: Use the configured style when naming methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars
-  Enabled: true
-  EnforcedStyle: snake_case
-  SupportedStyles:
-  - snake_case
-  - camelCase
 Layout/MultilineOperationIndentation:
   Description: Checks indentation of binary operations that span more than one line.
   Enabled: true
@@ -264,11 +112,6 @@ Style/NumericLiterals:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics
   Enabled: false
   MinDigits: 5
-Style/ParenthesesAroundCondition:
-  Description: Don't use parentheses around the condition of an if/unless/while.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-parens-if
-  Enabled: true
-  AllowSafeAssignment: true
 Style/PercentLiteralDelimiters:
   Description: Use `%`-literal delimiters consistently
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-literal-braces
@@ -283,13 +126,6 @@ Style/PercentLiteralDelimiters:
     "%w": "()"
     "%W": "()"
     "%x": "()"
-Style/PercentQLiterals:
-  Description: Checks if uses of %Q/%q match the configured preference.
-  Enabled: true
-  EnforcedStyle: lower_case_q
-  SupportedStyles:
-  - lower_case_q
-  - upper_case_q
 Naming/PredicateName:
   Description: Check the names of predicate methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
@@ -308,16 +144,6 @@ Style/RaiseArgs:
   SupportedStyles:
   - compact
   - exploded
-Style/RedundantReturn:
-  Description: Don't use return where it's not required.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-explicit-return
-  Enabled: true
-  AllowMultipleReturnValues: false
-Style/Semicolon:
-  Description: Don't use semicolons to terminate expressions.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-semicolon
-  Enabled: true
-  AllowAsExpressionSeparator: false
 Style/SignalException:
   Description: Checks for proper usage of fail and raise.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method
@@ -351,70 +177,6 @@ Style/StringLiterals:
   SupportedStyles:
   - single_quotes
   - double_quotes
-Style/StringLiteralsInInterpolation:
-  Description: Checks if uses of quotes inside expressions in interpolated strings
-    match the configured preference.
-  Enabled: true
-  EnforcedStyle: single_quotes
-  SupportedStyles:
-  - single_quotes
-  - double_quotes
-Layout/SpaceAroundBlockParameters:
-  Description: Checks the spacing inside and after block parameters pipes.
-  Enabled: true
-  EnforcedStyleInsidePipes: no_space
-  SupportedStylesInsidePipes:
-  - space
-  - no_space
-Layout/SpaceAroundEqualsInParameterDefault:
-  Description: Checks that the equals signs in parameter default assignments have
-    or don't have surrounding space depending on configuration.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-around-equals
-  Enabled: true
-  EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
-Layout/SpaceBeforeBlockBraces:
-  Description: Checks that the left block brace has or doesn't have space before it.
-  Enabled: true
-  EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
-Layout/SpaceInsideBlockBraces:
-  Description: Checks that block braces have or don't have surrounding space. For
-    blocks taking parameters, checks that the left brace has or doesn't have trailing
-    space.
-  Enabled: true
-  EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
-  EnforcedStyleForEmptyBraces: no_space
-  SpaceBeforeBlockParameters: true
-Layout/SpaceInsideHashLiteralBraces:
-  Description: Use spaces inside hash literal braces - or don't.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-  EnforcedStyle: space
-  EnforcedStyleForEmptyBraces: no_space
-  SupportedStyles:
-  - space
-  - no_space
-Style/SymbolProc:
-  Description: Use symbols as procs instead of blocks when possible.
-  Enabled: true
-  IgnoredMethods:
-  - respond_to
-Layout/TrailingBlankLines:
-  Description: Checks trailing blank lines and final newline.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#newline-eof
-  Enabled: true
-  EnforcedStyle: final_newline
-  SupportedStyles:
-  - final_newline
-  - final_blank_line
 Style/TrailingCommaInArguments:
   Description: Checks for trailing comma in argument lists.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
@@ -452,14 +214,6 @@ Style/TrivialAccessors:
   - to_str
   - to_s
   - to_sym
-Naming/VariableName:
-  Description: Use the configured style when naming variables.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars
-  Enabled: true
-  EnforcedStyle: snake_case
-  SupportedStyles:
-  - snake_case
-  - camelCase
 Style/WhileUntilModifier:
   Description: Favor modifier while/until usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier
@@ -485,11 +239,6 @@ Metrics/ClassLength:
   Enabled: false
   CountComments: false
   Max: 100
-Metrics/CyclomaticComplexity:
-  Description: A complexity metric that is strongly correlated to the number of test
-    cases needed to validate a method.
-  Enabled: true
-  Max: 6
 Metrics/LineLength:
   Description: Limit lines to 100 characters.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#100-character-limits
@@ -513,11 +262,6 @@ Metrics/ParameterLists:
   Enabled: false
   Max: 5
   CountKeywordArgs: true
-Metrics/PerceivedComplexity:
-  Description: A complexity metric geared towards measuring complexity for a human
-    reader.
-  Enabled: true
-  Max: 7
 Lint/AssignmentInCondition:
   Description: Don't use assignment in conditions.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition
@@ -537,50 +281,6 @@ Layout/DefEndAlignment:
   SupportedStylesAlignWith:
   - start_of_line
   - def
-Rails/ActionFilter:
-  Description: Enforces consistent use of action filter methods.
-  Enabled: true
-  EnforcedStyle: action
-  SupportedStyles:
-  - action
-  - filter
-  Include:
-  - app/controllers/**/*.rb
-Rails/HasAndBelongsToMany:
-  Description: Prefer has_many :through to has_and_belongs_to_many.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
-Rails/Output:
-  Description: Checks for calls to puts, print, etc.
-  Enabled: true
-  Include:
-  - app/**/*.rb
-  - config/**/*.rb
-  - db/**/*.rb
-  - lib/**/*.rb
-Rails/ReadWriteAttribute:
-  Description: Checks for read_attribute(:attr) and write_attribute(:attr, val).
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
-Rails/ScopeArgs:
-  Description: Checks the arguments of ActiveRecord scopes.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
-Rails/Validation:
-  Description: Use validates :attribute, hash of validations.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
-Style/InlineComment:
-  Description: Avoid inline comments.
-  Enabled: false
-Style/MethodCalledOnDoEndBlock:
-  Description: Avoid chaining a method call on a do...end block.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#single-line-blocks
-  Enabled: false
 Style/SymbolArray:
   Description: Use %i or %I for arrays of symbols.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-i
@@ -595,10 +295,6 @@ Style/Alias:
   Description: Use alias_method instead of alias.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
   Enabled: false
-Layout/AlignArray:
-  Description: Align the elements of an array literal if they span more than one line.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays
-  Enabled: true
 Style/ArrayJoin:
   Description: Use Array#join instead of Array#*.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#array-join
@@ -615,17 +311,10 @@ Style/Attr:
   Description: Checks for uses of Module#attr.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#attr
   Enabled: false
-Style/BeginBlock:
-  Description: Avoid the use of BEGIN blocks.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-BEGIN-blocks
-  Enabled: true
 Style/BlockComments:
   Description: Do not use block comments.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-block-comments
   Enabled: false
-Layout/BlockEndNewline:
-  Description: Put end statement of multiline block on its own line.
-  Enabled: true
 Style/CaseEquality:
   Description: Avoid explicit use of the case equality operator(===).
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-case-equality
@@ -634,10 +323,6 @@ Style/CharacterLiteral:
   Description: Checks for uses of character literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-character-literals
   Enabled: false
-Naming/ClassAndModuleCamelCase:
-  Description: Use CamelCase for classes and modules.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#camelcase-classes
-  Enabled: true
 Style/ClassMethods:
   Description: Use self when defining module/class methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#def-self-singletons
@@ -650,17 +335,6 @@ Style/ColonMethodCall:
   Description: 'Do not use :: for method call.'
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#double-colons
   Enabled: false
-Layout/CommentIndentation:
-  Description: Indentation of comments.
-  Enabled: true
-Naming/ConstantName:
-  Description: Constants should use SCREAMING_SNAKE_CASE.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#screaming-snake-case
-  Enabled: true
-Style/DefWithParentheses:
-  Description: Use def with parentheses when there are arguments.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#method-parens
-  Enabled: true
 Style/PreferredHashMethods:
   Description: Checks for use of deprecated Hash methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-key
@@ -675,29 +349,13 @@ Style/DoubleNegation:
 Style/EachWithObject:
   Description: Prefer `each_with_object` over `inject` or `reduce`.
   Enabled: false
-Layout/ElseAlignment:
-  Description: Align elses and elsifs correctly.
-  Enabled: true
 Style/EmptyElse:
   Description: Avoid empty else-clauses.
-  Enabled: true
-Layout/EmptyLines:
-  Description: Don't use several empty lines in a row.
-  Enabled: true
-Layout/EmptyLinesAroundAccessModifier:
-  Description: Keep blank lines around access modifiers.
-  Enabled: true
-Layout/EmptyLinesAroundMethodBody:
-  Description: Keeps track of empty lines around method bodies.
   Enabled: true
 Style/EmptyLiteral:
   Description: Prefer literals to Array.new/Hash.new/String.new.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#literal-array-hash
   Enabled: false
-Style/EndBlock:
-  Description: Avoid the use of END blocks.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-END-blocks
-  Enabled: true
 Layout/EndOfLine:
   Description: Use Unix-style line endings.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#crlf
@@ -714,32 +372,14 @@ Style/IfWithSemicolon:
   Description: Do not use if x; .... Use the ternary operator instead.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs
   Enabled: false
-Layout/IndentationConsistency:
-  Description: Keep indentation straight.
-  Enabled: true
-Layout/IndentArray:
-  Description: Checks the indentation of the first element in an array literal.
-  Enabled: true
-Style/InfiniteLoop:
-  Description: Use Kernel#loop for infinite loops.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#infinite-loop
-  Enabled: true
 Style/Lambda:
   Description: Use the new lambda literal syntax for single-line blocks.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#lambda-multi-line
   Enabled: false
-Layout/LeadingCommentSpace:
-  Description: Comments should start with a space.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-space
-  Enabled: true
 Style/LineEndConcatenation:
   Description: Use \ instead of + or << to concatenate two string literals at line
     end.
   Enabled: false
-Style/MethodCallWithoutArgsParentheses:
-  Description: Do not use parentheses for method calls with no arguments.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-args-no-parens
-  Enabled: true
 Style/ModuleFunction:
   Description: Checks for usage of `extend self` in modules.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#module-function
@@ -751,14 +391,6 @@ Style/MultilineBlockChain:
 Layout/MultilineBlockLayout:
   Description: Ensures newlines after multiline block do statements.
   Enabled: false
-Style/MultilineIfThen:
-  Description: Do not use then for multi-line if/unless.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-then
-  Enabled: true
-Style/MultilineTernaryOperator:
-  Description: 'Avoid multi-line ?: (the ternary operator); use if/unless instead.'
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-multiline-ternary
-  Enabled: true
 Style/NegatedIf:
   Description: Favor unless over if for negative conditions (or control flow or).
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#unless-for-negatives
@@ -767,18 +399,10 @@ Style/NegatedWhile:
   Description: Favor until over while for negative conditions.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#until-for-negatives
   Enabled: false
-Style/NestedTernaryOperator:
-  Description: Use one expression per branch in a ternary operator.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-ternary
-  Enabled: true
 Style/NilComparison:
   Description: Prefer x.nil? to x == nil.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#predicate-methods
   Enabled: false
-Style/Not:
-  Description: Use ! instead of not.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#bang-not-not
-  Enabled: true
 Style/OneLineConditional:
   Description: Favor the ternary operator(?:) over if/then/else/end constructs.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
@@ -795,63 +419,14 @@ Style/Proc:
   Description: Use proc instead of Proc.new.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#proc
   Enabled: false
-Style/RedundantBegin:
-  Description: Don't use begin blocks when they are not needed.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#begin-implicit
-  Enabled: true
-Style/RedundantException:
-  Description: Checks for an obsolete RuntimeException argument in raise/fail.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-explicit-runtimeerror
-  Enabled: true
-Style/RedundantSelf:
-  Description: Don't use self where it's not needed.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-self-unless-required
-  Enabled: true
-Style/RescueModifier:
-  Description: Avoid using rescue in its modifier form.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-rescue-modifiers
-  Enabled: true
 Style/SelfAssignment:
   Description: Checks for places where self-assignment shorthand should have been
     used.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#self-assignment
   Enabled: false
-Layout/SpaceAfterColon:
-  Description: Use spaces after colons.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Layout/SpaceAfterComma:
-  Description: Use spaces after commas.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Layout/SpaceAroundKeyword:
-  Description: Use a space around keywords if appropriate.
-  Enabled: true
-Layout/SpaceAfterMethodName:
-  Description: Do not put a space between a method name and the opening parenthesis
-    in a method definition.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
-  Enabled: true
-Layout/SpaceAfterNot:
-  Description: Tracks redundant space after the ! operator.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-bang
-  Enabled: true
-Layout/SpaceAfterSemicolon:
-  Description: Use spaces after semicolons.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Layout/SpaceBeforeComma:
-  Description: No spaces before commas.
-  Enabled: true
-Layout/SpaceBeforeComment:
-  Description: Checks for missing space between code and a comment on the same line.
-  Enabled: true
 Layout/SpaceBeforeFirstArg:
   Description: Put a space between a method name and the first argument in a method
     call without parentheses.
-  Enabled: true
-Layout/SpaceBeforeSemicolon:
-  Description: No spaces before semicolons.
   Enabled: true
 Layout/SpaceAroundOperators:
   Description: Use spaces around operators.
@@ -861,37 +436,10 @@ Layout/SpaceInsideParens:
   Description: No spaces after ( or before ).
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
   Enabled: true
-Layout/SpaceInsideRangeLiteral:
-  Description: No spaces inside range literals.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals
-  Enabled: true
 Style/SpecialGlobalVars:
   Description: Avoid Perl-style global variables.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms
   Enabled: false
-Style/StructInheritance:
-  Description: Checks for inheritance from Struct.new.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new
-  Enabled: true
-Layout/Tab:
-  Description: No hard tabs.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
-  Enabled: true
-Layout/TrailingWhitespace:
-  Description: Avoid trailing whitespace.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace
-  Enabled: true
-Style/UnlessElse:
-  Description: Do not use unless with else. Rewrite these with the positive case first.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-else-with-unless
-  Enabled: true
-Style/UnneededCapitalW:
-  Description: Checks for %W when interpolation is not needed.
-  Enabled: true
-Style/UnneededPercentQ:
-  Description: Checks for %q/%Q when single quotes or double quotes would do.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-q
-  Enabled: true
 Style/VariableInterpolation:
   Description: Don't interpolate global, instance and class variables directly in
     strings.
@@ -901,10 +449,6 @@ Style/WhenThen:
   Description: Use when x then ... for one-line cases.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#one-line-cases
   Enabled: false
-Style/WhileUntilDo:
-  Description: Checks for redundant do after while or until.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-multiline-while-do
-  Enabled: true
 Lint/AmbiguousOperator:
   Description: Checks for ambiguous operators in the first argument of a method invocation
     without parentheses.
@@ -922,34 +466,12 @@ Layout/ConditionPosition:
     keyword.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#same-line-condition
   Enabled: false
-Lint/Debugger:
-  Description: Check for debugger calls.
-  Enabled: true
 Lint/DeprecatedClassMethods:
   Description: Check for deprecated class method calls.
   Enabled: false
-Lint/DuplicateMethods:
-  Description: Check for duplicate methods calls.
-  Enabled: true
 Lint/ElseLayout:
   Description: Check for odd code arrangement in an else block.
   Enabled: false
-Lint/EmptyEnsure:
-  Description: Checks for empty ensure block.
-  Enabled: true
-Lint/EmptyInterpolation:
-  Description: Checks for empty string interpolation.
-  Enabled: true
-Lint/EndInMethod:
-  Description: END blocks should not be placed inside method definitions.
-  Enabled: true
-Lint/EnsureReturn:
-  Description: Do not use return in an ensure block.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-return-ensure
-  Enabled: true
-Security/Eval:
-  Description: The use of eval represents a serious security risk.
-  Enabled: true
 Lint/HandleExceptions:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
@@ -972,48 +494,9 @@ Lint/ParenthesesAsGroupedExpression:
 Lint/RequireParentheses:
   Description: Use parentheses in the method call to avoid confusion about precedence.
   Enabled: false
-Lint/RescueException:
-  Description: Avoid rescuing the Exception class.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-blind-rescues
-  Enabled: true
-Lint/ShadowingOuterLocalVariable:
-  Description: Do not use the same name as outer local variable for block arguments
-    or block local variables.
-  Enabled: true
-Lint/StringConversionInInterpolation:
-  Description: Checks for Object#to_s usage in string interpolation.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-to-s
-  Enabled: true
 Lint/UnderscorePrefixedVariableName:
   Description: Do not use prefix `_` for a variable that is used.
   Enabled: false
-Lint/UnusedBlockArgument:
-  Description: Checks for unused block arguments.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars
-  Enabled: true
-Lint/UnusedMethodArgument:
-  Description: Checks for unused method arguments.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars
-  Enabled: true
-Lint/UnreachableCode:
-  Description: Unreachable code.
-  Enabled: true
-Lint/UselessAccessModifier:
-  Description: Checks for useless access modifiers.
-  Enabled: true
-Lint/UselessAssignment:
-  Description: Checks for useless assignment to a local variable.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars
-  Enabled: true
-Lint/UselessComparison:
-  Description: Checks for comparison of something with itself.
-  Enabled: true
-Lint/UselessElseWithoutRescue:
-  Description: Checks for useless `else` in `begin..end` without `rescue`.
-  Enabled: true
-Lint/UselessSetterCall:
-  Description: Checks for useless setter call to a local variable.
-  Enabled: true
 Lint/Void:
   Description: Possible use of operator/literal/variable in void context.
   Enabled: false
@@ -1024,621 +507,3 @@ Performance/RedundantBlockCall:
   Description: Use `yield` instead of `block.call`.
   Reference: https://github.com/JuanitoFatas/fast-ruby#proccall-vs-yield-code
   Enabled: false
-
-
-# The following cops are added between 0.49.1 and 0.61.1.
-# The configurations are default.
-# If you want to use a cop by default, remove a configuration for the cop from here.
-# If you want to disable a cop, change `Enabled` to false.
-
-Bundler/GemComment:
-  Description: Add a comment describing each gem.
-  Enabled: false
-  VersionAdded: '0.59'
-  Include:
-  - "**/*.gemfile"
-  - "**/Gemfile"
-  - "**/gems.rb"
-  Whitelist: []
-
-# Supports --auto-correct
-Bundler/InsecureProtocolSource:
-  Description: The source `:gemcutter`, `:rubygems` and `:rubyforge` are deprecated
-    because HTTP requests are insecure. Please change your source to 'https://rubygems.org'
-    if possible, or 'http://rubygems.org' if not.
-  Enabled: true
-  VersionAdded: '0.50'
-  Include:
-  - "**/*.gemfile"
-  - "**/Gemfile"
-  - "**/gems.rb"
-
-Gemspec/DuplicatedAssignment:
-  Description: An attribute assignment method calls should be listed only once in a
-    gemspec.
-  Enabled: true
-  VersionAdded: '0.52'
-  Include:
-  - "**/*.gemspec"
-
-# Supports --auto-correct
-Gemspec/OrderedDependencies:
-  Description: Dependencies in the gemspec should be alphabetically sorted.
-  Enabled: true
-  VersionAdded: '0.51'
-  TreatCommentsAsGroupSeparators: true
-  Include:
-  - "**/*.gemspec"
-
-Gemspec/RequiredRubyVersion:
-  Description: Checks that `required_ruby_version` of gemspec and `TargetRubyVersion`
-    of .rubocop.yml are equal.
-  Enabled: true
-  VersionAdded: '0.52'
-  Include:
-  - "**/*.gemspec"
-
-# Supports --auto-correct
-Layout/ClassStructure:
-  Description: Enforces a configured order of definitions within a class body.
-  StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#consistent-classes
-  Enabled: false
-  VersionAdded: '0.52'
-  Categories:
-    module_inclusion:
-    - include
-    - prepend
-    - extend
-  ExpectedOrder:
-  - module_inclusion
-  - constants
-  - public_class_methods
-  - initializer
-  - public_methods
-  - protected_methods
-  - private_methods
-
-# Supports --auto-correct
-Layout/ClosingHeredocIndentation:
-  Description: Checks the indentation of here document closings.
-  Enabled: true
-  VersionAdded: '0.57'
-
-# Supports --auto-correct
-Layout/EmptyComment:
-  Description: Checks empty comment.
-  Enabled: true
-  VersionAdded: '0.53'
-  AllowBorderComment: true
-  AllowMarginComment: true
-
-# Supports --auto-correct
-Layout/EmptyLineAfterGuardClause:
-  Description: Add empty line after guard clause.
-  Enabled: true
-  VersionAdded: '0.56'
-  VersionChanged: '0.59'
-
-# Supports --auto-correct
-Layout/EmptyLinesAroundArguments:
-  Description: Keeps track of empty lines around method arguments.
-  Enabled: true
-  VersionAdded: '0.52'
-
-# Supports --auto-correct
-Layout/LeadingBlankLines:
-  Description: Check for unnecessary blank lines at the beginning of a file.
-  Enabled: true
-  VersionAdded: '0.57'
-
-# Supports --auto-correct
-Layout/SpaceInsideArrayLiteralBrackets:
-  Description: Checks the spacing inside array literal brackets.
-  Enabled: true
-  VersionAdded: '0.52'
-  EnforcedStyle: no_space
-  SupportedStyles:
-  - space
-  - no_space
-  - compact
-  EnforcedStyleForEmptyBrackets: no_space
-  SupportedStylesForEmptyBrackets:
-  - space
-  - no_space
-
-# Supports --auto-correct
-Layout/SpaceInsideReferenceBrackets:
-  Description: Checks the spacing inside referential brackets.
-  Enabled: true
-  VersionAdded: '0.52'
-  VersionChanged: '0.53'
-  EnforcedStyle: no_space
-  SupportedStyles:
-  - space
-  - no_space
-  EnforcedStyleForEmptyBrackets: no_space
-  SupportedStylesForEmptyBrackets:
-  - space
-  - no_space
-
-# Supports --auto-correct
-Lint/BigDecimalNew:
-  Description: "`BigDecimal.new()` is deprecated. Use `BigDecimal()` instead."
-  Enabled: true
-  VersionAdded: '0.53'
-
-Lint/BooleanSymbol:
-  Description: Check for `:true` and `:false` symbols.
-  Enabled: true
-  VersionAdded: '0.50'
-
-Lint/ErbNewArguments:
-  Description: Use `:trim_mode` and `:eoutvar` keyword arguments to `ERB.new`.
-  Enabled: true
-  VersionAdded: '0.56'
-
-Lint/InterpolationCheck:
-  Description: Raise warning for interpolation in single q strs
-  Enabled: true
-  VersionAdded: '0.50'
-
-Lint/MissingCopEnableDirective:
-  Description: Checks for a `# rubocop:enable` after `# rubocop:disable`
-  Enabled: true
-  VersionAdded: '0.52'
-  MaximumRangeSize: .inf
-
-Lint/NestedPercentLiteral:
-  Description: Checks for nested percent literals.
-  Enabled: true
-  VersionAdded: '0.52'
-
-Lint/NumberConversion:
-  Description: Checks unsafe usage of number conversion methods.
-  Enabled: false
-  VersionAdded: '0.53'
-
-# Supports --auto-correct
-Lint/OrderedMagicComments:
-  Description: Checks the proper ordering of magic comments and whether a magic comment
-    is not placed before a shebang.
-  Enabled: true
-  VersionAdded: '0.53'
-
-# Supports --auto-correct
-Lint/RedundantWithIndex:
-  Description: Checks for redundant `with_index`.
-  Enabled: true
-  VersionAdded: '0.50'
-
-# Supports --auto-correct
-Lint/RedundantWithObject:
-  Description: Checks for redundant `with_object`.
-  Enabled: true
-  VersionAdded: '0.51'
-
-Lint/RegexpAsCondition:
-  Description: Do not use regexp literal as a condition. The regexp literal matches
-    `$_` implicitly.
-  Enabled: true
-  VersionAdded: '0.51'
-
-Lint/ReturnInVoidContext:
-  Description: Checks for return in void context.
-  Enabled: true
-  VersionAdded: '0.50'
-
-# Supports --auto-correct
-Lint/SafeNavigationConsistency:
-  Description: Check to make sure that if safe navigation is used for a method call
-    in an `&&` or `||` condition that safe navigation is used for all method calls on
-    that same object.
-  Enabled: true
-  VersionAdded: '0.55'
-  Whitelist:
-  - present?
-  - blank?
-  - presence
-  - try
-  - try!
-
-Lint/ShadowedArgument:
-  Description: Avoid reassigning arguments before they were used.
-  Enabled: true
-  VersionAdded: '0.52'
-  IgnoreImplicitReferences: false
-
-# Supports --auto-correct
-Lint/UnneededCopEnableDirective:
-  Description: Checks for rubocop:enable comments that can be removed.
-  Enabled: true
-  VersionAdded: '0.53'
-
-# Supports --auto-correct
-Lint/UnneededRequireStatement:
-  Description: Checks for unnecessary `require` statement.
-  Enabled: true
-  VersionAdded: '0.51'
-
-Lint/UriEscapeUnescape:
-  Description: "`URI.escape` method is obsolete and should not be used. Instead, use
-    `CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component` depending
-    on your specific use case. Also `URI.unescape` method is obsolete and should not
-    be used. Instead, use `CGI.unescape`, `URI.decode_www_form` or `URI.decode_www_form_component`
-    depending on your specific use case."
-  Enabled: true
-  VersionAdded: '0.50'
-
-# Supports --auto-correct
-Lint/UriRegexp:
-  Description: Use `URI::DEFAULT_PARSER.make_regexp` instead of `URI.regexp`.
-  Enabled: true
-  VersionAdded: '0.50'
-
-Naming/HeredocDelimiterCase:
-  Description: Use configured case for heredoc delimiters.
-  StyleGuide: "#heredoc-delimiters"
-  Enabled: true
-  VersionAdded: '0.50'
-  EnforcedStyle: uppercase
-  SupportedStyles:
-  - lowercase
-  - uppercase
-
-Naming/HeredocDelimiterNaming:
-  Description: Use descriptive heredoc delimiters.
-  StyleGuide: "#heredoc-delimiters"
-  Enabled: true
-  VersionAdded: '0.50'
-  Blacklist:
-  - !ruby/regexp /(^|\s)(EO[A-Z]{1}|END)(\s|$)/
-
-Naming/MemoizedInstanceVariableName:
-  Description: Memoized method name should match memo instance variable name.
-  Enabled: true
-  VersionAdded: '0.53'
-  VersionChanged: '0.58'
-  EnforcedStyleForLeadingUnderscores: disallowed
-  SupportedStylesForLeadingUnderscores:
-  - disallowed
-  - required
-  - optional
-
-Naming/UncommunicativeBlockParamName:
-  Description: Checks for block parameter names that contain capital letters, end in
-    numbers, or do not meet a minimal length.
-  Enabled: true
-  VersionAdded: '0.53'
-  MinNameLength: 1
-  AllowNamesEndingInNumbers: true
-  AllowedNames: []
-  ForbiddenNames: []
-
-Naming/UncommunicativeMethodParamName:
-  Description: Checks for method parameter names that contain capital letters, end in
-    numbers, or do not meet a minimal length.
-  Enabled: true
-  VersionAdded: '0.53'
-  VersionChanged: '0.59'
-  MinNameLength: 3
-  AllowNamesEndingInNumbers: true
-  AllowedNames:
-  - io
-  - id
-  - to
-  - by
-  - 'on'
-  - in
-  - at
-  - ip
-  - db
-  ForbiddenNames: []
-
-Performance/ChainArrayAllocation:
-  Description: Instead of chaining array methods that allocate new arrays, mutate an
-    existing array.
-  Reference: https://twitter.com/schneems/status/1034123879978029057
-  Enabled: false
-  VersionAdded: '0.59'
-
-# Supports --auto-correct
-Performance/InefficientHashSearch:
-  Description: Use `key?` or `value?` instead of `keys.include?` or `values.include?`
-  Reference: https://github.com/JuanitoFatas/fast-ruby#hashkey-instead-of-hashkeysinclude-code
-  Enabled: true
-  VersionAdded: '0.56'
-  Safe: false
-
-Performance/UnfreezeString:
-  Description: Use unary plus to get an unfrozen string literal.
-  Enabled: true
-  VersionAdded: '0.50'
-
-# Supports --auto-correct
-Performance/UnneededSort:
-  Description: Use `min` instead of `sort.first`, `max_by` instead of `sort_by...last`,
-    etc.
-  Enabled: true
-  VersionAdded: '0.55'
-
-# Supports --auto-correct
-Performance/UriDefaultParser:
-  Description: Use `URI::DEFAULT_PARSER` instead of `URI::Parser.new`.
-  Enabled: true
-  VersionAdded: '0.50'
-
-# Supports --auto-correct
-Rails/ActiveRecordAliases:
-  Description: 'Avoid Active Record aliases: Use `update` instead of `update_attributes`.
-    Use `update!` instead of `update_attributes!`.'
-  Enabled: true
-  VersionAdded: '0.53'
-
-# Supports --auto-correct
-Rails/AssertNot:
-  Description: Use `assert_not` instead of `assert !`.
-  Enabled: true
-  VersionAdded: '0.56'
-  Include:
-  - "**/test/**/*"
-
-Rails/BulkChangeTable:
-  Description: Check whether alter queries are combinable.
-  Enabled: true
-  VersionAdded: '0.57'
-  Database: 
-  SupportedDatabases:
-  - mysql
-  - postgresql
-  Include:
-  - db/migrate/*.rb
-
-Rails/CreateTableWithTimestamps:
-  Description: Checks the migration for which timestamps are not included when creating
-    a new table.
-  Enabled: true
-  VersionAdded: '0.52'
-  Include:
-  - db/migrate/*.rb
-
-# Supports --auto-correct
-Rails/EnvironmentComparison:
-  Description: Favor `Rails.env.production?` over `Rails.env == 'production'`
-  Enabled: true
-  VersionAdded: '0.52'
-
-Rails/HasManyOrHasOneDependent:
-  Description: Define the dependent option to the has_many and has_one associations.
-  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#has_many-has_one-dependent-option
-  Enabled: true
-  VersionAdded: '0.50'
-  Include:
-  - app/models/**/*.rb
-
-Rails/InverseOf:
-  Description: Checks for associations where the inverse cannot be determined automatically.
-  Enabled: true
-  VersionAdded: '0.52'
-  Include:
-  - app/models/**/*.rb
-
-Rails/LexicallyScopedActionFilter:
-  Description: Checks that methods specified in the filter's `only` or `except` options
-    are explicitly defined in the controller.
-  StyleGuide: https://github.com/rubocop-hq/rails-style-guide#lexically-scoped-action-filter
-  Enabled: true
-  VersionAdded: '0.52'
-  Include:
-  - app/controllers/**/*.rb
-
-# Supports --auto-correct
-Rails/Presence:
-  Description: Checks code that can be written more easily using `Object#presence` defined
-    by Active Support.
-  Enabled: true
-  VersionAdded: '0.52'
-
-# Supports --auto-correct
-Rails/RedundantReceiverInWithOptions:
-  Description: Checks for redundant receiver in `with_options`.
-  Enabled: true
-  VersionAdded: '0.52'
-
-# Supports --auto-correct
-Rails/RefuteMethods:
-  Description: Use `assert_not` methods instead of `refute` methods.
-  Enabled: true
-  VersionAdded: '0.56'
-  Include:
-  - "**/test/**/*"
-
-Rails/UnknownEnv:
-  Description: Use correct environment name.
-  Enabled: true
-  VersionAdded: '0.51'
-  Environments:
-  - development
-  - test
-  - production
-
-Security/Open:
-  Description: The use of Kernel#open represents a serious security risk.
-  Enabled: true
-  VersionAdded: '0.53'
-  Safe: false
-
-Style/AccessModifierDeclarations:
-  Description: Checks style of how access modifiers are used.
-  Enabled: true
-  VersionAdded: '0.57'
-  EnforcedStyle: group
-  SupportedStyles:
-  - inline
-  - group
-
-# Supports --auto-correct
-Style/ColonMethodDefinition:
-  Description: 'Do not use :: for defining class methods.'
-  StyleGuide: "#colon-method-definition"
-  Enabled: true
-  VersionAdded: '0.52'
-
-Style/CommentedKeyword:
-  Description: Do not place comments on the same line as certain keywords.
-  Enabled: true
-  VersionAdded: '0.51'
-
-Style/DateTime:
-  Description: Use Time over DateTime.
-  StyleGuide: "#date--time"
-  Enabled: false
-  VersionAdded: '0.51'
-  VersionChanged: '0.59'
-  AllowCoercion: false
-
-# Supports --auto-correct
-Style/Dir:
-  Description: Use the `__dir__` method to retrieve the canonicalized absolute path
-    to the current file.
-  Enabled: true
-  VersionAdded: '0.50'
-
-# Supports --auto-correct
-Style/EmptyBlockParameter:
-  Description: Omit pipes for empty block parameters.
-  Enabled: true
-  VersionAdded: '0.52'
-
-# Supports --auto-correct
-Style/EmptyLambdaParameter:
-  Description: Omit parens for empty lambda parameters.
-  Enabled: true
-  VersionAdded: '0.52'
-
-Style/EvalWithLocation:
-  Description: Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by
-    backtraces.
-  Enabled: true
-  VersionAdded: '0.52'
-
-# Supports --auto-correct
-Style/ExpandPathArguments:
-  Description: Use `expand_path(__dir__)` instead of `expand_path('..', __FILE__)`.
-  Enabled: true
-  VersionAdded: '0.53'
-
-Style/IpAddresses:
-  Description: Don't include literal IP addresses in code.
-  Enabled: false
-  VersionAdded: '0.58'
-  Whitelist:
-  - "::"
-
-# Supports --auto-correct
-Style/MinMax:
-  Description: Use `Enumerable#minmax` instead of `Enumerable#min` and `Enumerable#max`
-    in conjunction.'
-  Enabled: true
-  VersionAdded: '0.50'
-
-Style/MixinUsage:
-  Description: Checks that `include`, `extend` and `prepend` exists at the top level.
-  Enabled: true
-  VersionAdded: '0.51'
-
-Style/MultilineMethodSignature:
-  Description: Avoid multi-line method signatures.
-  Enabled: false
-  VersionAdded: '0.59'
-
-# Supports --auto-correct
-Style/OrAssignment:
-  Description: Recommend usage of double pipe equals (||=) where applicable.
-  StyleGuide: "#double-pipe-for-uninit"
-  Enabled: true
-  VersionAdded: '0.50'
-
-# Supports --auto-correct
-Style/RandomWithOffset:
-  Description: Prefer to use ranges when generating random numbers instead of integers
-    with offsets.
-  StyleGuide: "#random-numbers"
-  Enabled: true
-  VersionAdded: '0.52'
-
-# Supports --auto-correct
-Style/RedundantConditional:
-  Description: Don't return true/false from a conditional.
-  Enabled: true
-  VersionAdded: '0.50'
-
-# Supports --auto-correct
-Style/RescueStandardError:
-  Description: Avoid rescuing without specifying an error class.
-  Enabled: true
-  VersionAdded: '0.52'
-  EnforcedStyle: explicit
-  SupportedStyles:
-  - implicit
-  - explicit
-
-# Supports --auto-correct
-Style/ReturnNil:
-  Description: Use return instead of return nil.
-  Enabled: false
-  EnforcedStyle: return
-  SupportedStyles:
-  - return
-  - return_nil
-  VersionAdded: '0.50'
-
-# Supports --auto-correct
-Style/StderrPuts:
-  Description: Use `warn` instead of `$stderr.puts`.
-  StyleGuide: "#warn"
-  Enabled: true
-  VersionAdded: '0.51'
-
-# Supports --auto-correct
-Style/StringHashKeys:
-  Description: Prefer symbols instead of strings as hash keys.
-  StyleGuide: "#symbols-as-keys"
-  Enabled: false
-  VersionAdded: '0.52'
-
-# Supports --auto-correct
-Style/TrailingBodyOnClass:
-  Description: Class body goes below class statement.
-  Enabled: true
-  VersionAdded: '0.53'
-
-# Supports --auto-correct
-Style/TrailingBodyOnMethodDefinition:
-  Description: Method body goes below definition.
-  Enabled: true
-  VersionAdded: '0.52'
-
-# Supports --auto-correct
-Style/TrailingBodyOnModule:
-  Description: Module body goes below module statement.
-  Enabled: true
-  VersionAdded: '0.53'
-
-# Supports --auto-correct
-Style/TrailingMethodEndStatement:
-  Description: Checks for trailing end statement on line of method body.
-  Enabled: true
-  VersionAdded: '0.52'
-
-# Supports --auto-correct
-Style/UnneededCondition:
-  Description: Checks for unnecessary conditional expressions.
-  Enabled: true
-  VersionAdded: '0.57'
-
-# Supports --auto-correct
-Style/UnpackFirst:
-  Description: Checks for accessing the first element of `String#unpack` instead of
-    using `unpack1`
-  Enabled: true
-  VersionAdded: '0.54'

--- a/style/config/.rubocop.yml
+++ b/style/config/.rubocop.yml
@@ -4,7 +4,6 @@ AllCops:
   - "db/**/*"
   - "bin/**/*"
   DisplayCopNames: false
-  StyleGuideCopsOnly: false
   TargetRubyVersion: 2.5
 Rails:
   Enabled: true

--- a/style/config/.rubocop.yml
+++ b/style/config/.rubocop.yml
@@ -297,10 +297,6 @@ Style/CharacterLiteral:
   Description: Checks for uses of character literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-character-literals
   Enabled: false
-Style/ClassMethods:
-  Description: Use self when defining module/class methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#def-self-singletons
-  Enabled: true
 Style/ClassVars:
   Description: Avoid the use of class variables.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-class-vars

--- a/style/config/.rubocop.yml
+++ b/style/config/.rubocop.yml
@@ -36,20 +36,6 @@ Style/CommentAnnotation:
   - OPTIMIZE
   - HACK
   - REVIEW
-Layout/EmptyLinesAroundClassBody:
-  Description: Keeps track of empty lines around class bodies.
-  Enabled: true
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
-Layout/EmptyLinesAroundModuleBody:
-  Description: Keeps track of empty lines around module bodies.
-  Enabled: true
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
 Naming/FileName:
   Description: Use snake_case for source file names.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
@@ -153,17 +139,6 @@ Style/SignalException:
   - only_raise
   - only_fail
   - semantic
-Style/SingleLineBlockParams:
-  Description: Enforces the names of some block params.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#reduce-blocks
-  Enabled: false
-  Methods:
-  - reduce:
-    - a
-    - e
-  - inject:
-    - a
-    - e
 Style/SingleLineMethods:
   Description: Avoid single-line methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-single-line-methods


### PR DESCRIPTION
Ya que el comportamiento de rubocop es usar las reglas por defecto y sólo re-escribir las que estén definidas en el `.rubocop.yml` que se le especifique al hacer lint (https://rubocop.readthedocs.io/en/latest/configuration/#defaults), un montón de reglas que estaban definidas eran redundantes lo que, aparte de hacer más largo el archivo de reglas, hace que mantener este archivo sea mucho más difícil.

En este PR se eliminan la mayoría de las reglas redundantes que encontré. Las que siguen en este archivo están porque:

 - O se me pasó
 - O la regla definida en el estilo por defecto incluye alguna opción que no tiene un equivalente definido en nuestras reglas y por lo tanto no me queda claro si el comportamiento es igual.
 - O la regla define una opción diferente a nuestras reglas (está desactivado/apagado y el nuestro al revés o especifica otras opciones diferentes)

Comentaré las reglas que hay que re-revisar (el segundo caso) para que vayamos viéndolo. 