### PR TITLE
style(rubocop): disable pluralization rules 👮‍♂️

### DIFF
--- a/style/config/.rubocop.yml
+++ b/style/config/.rubocop.yml
@@ -477,3 +477,7 @@ Performance/RedundantBlockCall:
   Description: Use `yield` instead of `block.call`.
   Reference: https://github.com/JuanitoFatas/fast-ruby#proccall-vs-yield-code
   Enabled: false
+Rails/PluralizationGrammar:
+  Description: 'Checks for incorrect grammar when using methods like `3.day.ago`.'
+  Enabled: false
+  VersionAdded: '0.35'


### PR DESCRIPTION
## Descripción

Se desactiva la regla de pluralización de Rails (https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Rails/PluralizationGrammar)