### PR TITLE
Rubocop rspec

### DIFF
--- a/code/style.md
+++ b/code/style.md
@@ -39,6 +39,7 @@ Para poder ejecutar la revisión de reglas localmente es que necesitamos de los 
 ```sh
 # ruby
 gem install rubocop -v '0.65.0'
+gem install rubocop-rspec
 
 # js
 npm install -g eslint

--- a/style/config/.rubocop.yml
+++ b/style/config/.rubocop.yml
@@ -1,3 +1,4 @@
+require: rubocop-rspec
 AllCops:
   Exclude:
   - "vendor/**/*"
@@ -477,3 +478,14 @@ Performance/RedundantBlockCall:
   Description: Use `yield` instead of `block.call`.
   Reference: https://github.com/JuanitoFatas/fast-ruby#proccall-vs-yield-code
   Enabled: false
+RSpec/MultipleExpectations:
+  Max: 5
+RSpec/NestedGroups:
+  Max: 5
+RSpec/ExampleLength:
+  Max: 10
+RSpec/LetSetup:
+  Enabled: false
+RSpec/ExpectChange:
+  Enabled: true
+  EnforcedStyle: block


### PR DESCRIPTION
## Descripción

Desde hace un tiempo agregamos este cop al proyecto Ksec para evitar que por agregar un foco en un spec (p.ej `fit`), la suite de tests pasara haciendo 1 solo test en vez de los ~1500.

Hemos estado usando este cop y hemos ido puliendo la configuración para adaptarse al estilo que tenemos en platanus. Hasta ahora creo que ha sido una buena experiencia: 
 - ya no se nos pasan los `fit`
 -  ayuda como guía a la hora de hacer specs 
 - ayuda a mantener un estilo similar entre todos los specs (por ejemplo un salto de línea después del último `let`, que los `context` comiencen con `when...`, etc.

## Cambios

 - Se agrega `rubocop-rspec` como dependencia al `.rubocop` que corre el mono
 - Se agrega `rubocop-rspoc` como gema requerida para correr los linters en la parte de estilos