### PR TITLE
feat(eslint): add -1 as ignored magic number

### DIFF
--- a/style/config/.eslintrc.json
+++ b/style/config/.eslintrc.json
@@ -61,7 +61,7 @@
     "no-lone-blocks": 2,
     "no-loop-func": 2,
     "no-magic-numbers": [2, {
-      "ignore": [0, 1]
+      "ignore": [0, 1, -1]
     }],
     "no-multi-spaces": 2,
     "no-multi-str": 2,


### PR DESCRIPTION
Se agrega -1 como magic-number ignorado.

La razón es por funciones de JS que entregan -1 como resultado deseado como por ejemplo:

`Array.indexOf(element) === -1` cuando el elemento no está en el array o
`sort((a, b) => a > b ? 1 : -1)` al ordenar