### PR TITLE
fix(code-style): add rubocop-rspec version specification

### DIFF
--- a/code/style.md
+++ b/code/style.md
@@ -39,7 +39,7 @@ Para poder ejecutar la revisión de reglas localmente es que necesitamos de los 
 ```sh
 # ruby
 gem install rubocop -v '0.65.0'
-gem install rubocop-rspec
+gem install rubocop-rspec -v '1.35.0'
 
 # js
 npm install -g eslint


### PR DESCRIPTION
Rubocop-rspec added a rubocop latest version installation on their [1.36.0](https://github.com/rubocop-hq/rubocop-rspec/compare/v1.35.0...v1.36.0) release ([in this commit](https://github.com/rubocop-hq/rubocop-rspec/commit/65cc815f844c0a92a477407a36d1ccee8bc5210e)). This overrides rubocop version 0.65.0 which is specified in this guide to avoid rule name changes. To avoid the override, specify rubocop-rspec version 1.35.0.