### PR TITLE
fix(linters): change vscode stylelint link

### DIFF
--- a/setup/local/linters.md
+++ b/setup/local/linters.md
@@ -37,7 +37,7 @@ Para correr los linters de manera más cómoda, podemos instalar los siguientes 
 * [Ruby](https://github.com/misogi/vscode-ruby-rubocop)
 * [ES](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 * [TypeScript](https://marketplace.visualstudio.com/items?itemName=eg2.tslint)
-* [stylelint](https://marketplace.visualstudio.com/items?itemName=shinnn.stylelint)
+* [stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint)
 
 Para que funcione Rubocop, se debe agregar la siguiente configuración en los Settings:
 


### PR DESCRIPTION
`shinnn.stylelint` ya no existe, se reemplaza por el plugin de vscode/stylelint con más downloads