### PR TITLE
feat(tslint): remove displeasing rule

### DIFF
--- a/style/config/tslint.json
+++ b/style/config/tslint.json
@@ -3,7 +3,6 @@
     "align": [
       true,
       "parameters",
-      "arguments",
       "statements"
     ],
     "class-name": true,


### PR DESCRIPTION
Encuentro que la regla de `align arguments` es muy molesta para `Typescript`

por ejemplo, si se usa una función como `setTimeout`

Esto se considera incorrecto

```
window.setTimeout(() => {
  ...
}, TIMEOUT_TIME);
```

y hay que hacerlo así:

```
window.setTimeout(() => {
  ...
},                TIMEOUT_TIME);
```

La otra opción sería (igual de mala):

```
window.setTimeout(
() => {
    ...
}, 
TIMEOUT_TIME);
```


Lo que me parece muy molesto. Todos los demás align hacen sentido, pero en typescript alinear los argumentos de una función, con callbacks y promesas de por medio, me parece muy feo a la vista.