### PR TITLE
Length rules

### DIFF
--- a/style/config/.eslintrc.json
+++ b/style/config/.eslintrc.json
@@ -246,7 +246,9 @@
     "linebreak-style": [2, "unix"],
     "lines-around-comment": 0,
     "max-depth": [2, 4],
-    "max-len": [2, 120],
+    "max-len": [2, 120, {
+      "ignorePattern": "^\\s.+class=\""
+    }],
     "max-nested-callbacks": [2, 4],
     "max-params": [1, 4],
     "max-statements": [1, 10],

--- a/style/config/.eslintrc.json
+++ b/style/config/.eslintrc.json
@@ -334,6 +334,10 @@
       "vars": "local",
       "args": "after-used"
     }],
-    "no-use-before-define": 2
+    "no-use-before-define": 2,
+    "vue/max-len": ["error", {
+      "code": 120,
+      "ignoreHTMLAttributeValues": true
+  }]
   }
 }


### PR DESCRIPTION
Se agregan reglas para facilitar el uso de tailwind:
- Se desactiva el máximo de largo para las lineas que empiezan con "class"
- Se desactiva la regla dentro de templates de vue si son atributos de html
- Se aumenta el máximo de largo a 120 dentro de los componentes de Vue para que quede igual que el javascript normal.