### PR TITLE
docs(shrine): add testing links

### DIFF
--- a/stack/ruby/rails/shrine.md
+++ b/stack/ruby/rails/shrine.md
@@ -162,10 +162,11 @@ include ProfilePictureUploader::Attachment(:profile_picture)
 ```
 
 ### Recursos útiles
-- [Documentación oficial](https://shrinerb.com/): muy buena, con guías y secciones explicando los distintos plugins.
+- [Documentación oficial](https://shrinerb.com/): muy buena, con guías y secciones explicando los distintos plugins
 - [Repo en Github](https://github.com/shrinerb/shrine)
 - [Direct S3 Upload](https://github.com/shrinerb/shrine/wiki/Adding-Direct-S3-Uploads) / [Direct App Upload](https://github.com/shrinerb/shrine/wiki/Adding-Direct-App-Uploads): ambos sirven para subir un archivo antes de que se le haga submit a un form. La diferencia radica en que el de S3 lo sube directamente a AWS, mientras que el otro lo sube a un `upload_endpoint` de la aplicación. Para ambientes que no tienen un bucket S3 (como `development`, en que se guardan los archivos en el filesystem) habría que usar Direct App Upload
 - [Demo Direct Upload + Vue](https://drive.google.com/file/d/1fwrZ1tLZa_xeSp2j57iKFgjNlgDxXAM9/view?usp=sharing): presentación al equipo de Platanus para introducir Shrine. Se arma un componente Vue para manejar el Direct Upload que puede ser usado dentro de un form de Rails
+- [Testing](https://shrinerb.com/docs/testing): en la sección de [Test data](https://shrinerb.com/docs/testing#test-data) dan un ejemplo de un helper que puede ser usado en las factories. En la sección de [Acceptance tests](https://shrinerb.com/docs/testing#acceptance-tests) dan un ejemplo de como agregar un archivo como parámetro en tests de controladores usando `Rack::Test::UploadedFile`
 
 #### Recursos útiles para plataneros
 - [Implementación Direct Upload](https://github.com/platanus/gret/pull/22): PR implementando Direct Upload para ser usado en ActiveAdmin


### PR DESCRIPTION
Se agregan links a partes útiles de la sección de testing de la guía de Shrine