### PR TITLE
Aa sections

### DIFF
--- a/stack/ruby/rails/activeadmin.md
+++ b/stack/ruby/rails/activeadmin.md
@@ -393,6 +393,43 @@ Hay veces que necesitamos agregar nuevos endpoints con HTML a medida. Para hacer
 
    sería equivalente a lo de `/app/views/admin/blogs/preview.html.erb` en Arbre.
 
+#### <a name="shrine-download"></a>Link de download para archivos
+
+> Para manejo de archivos se supone el uso de [Shrine](shrine.md)
+
+Suponiendo que el blog tiene un archivo `image`:
+
+1. Agregar la `member_action`:
+
+    ```
+    member_action :download, method: :get do
+      blog = Blog.find(params[:id])
+      send_file blog.image.download
+    end
+    ```
+
+2. Agregar el `action_item`:
+
+    ```
+    action_item :download, only: :show, if: -> { blog.image.present? } do
+      link_to 'Download', download_admin_blog_path(blog)
+    end
+    ```
+
+3. Agregar link a las `actions` en el index
+
+    ```
+    index do
+      column :id
+      .
+      .
+      .
+      actions defaults: true do |blog|
+        link_to 'Download Image', download_admin_blog_path(blog)
+      end
+    end
+    ```
+
 #### JavaScript en una vista
 
 Si necesitas agregar alguna pequeña inteligencia en una vista de Active Admin puedes:

--- a/stack/ruby/rails/activeadmin.md
+++ b/stack/ruby/rails/activeadmin.md
@@ -511,6 +511,19 @@ Muchas veces en un formulario de Active Admin necesitamos un input custom. Por e
 
 <img src="./assets/active-admin-custom-input.gif" />
 
+#### Filtros custom
+
+Para manejar la búsqueda de los filtros ActiveAdmin por debajo usa [Ransack](https://github.com/activerecord-hackery/ransack). Esta gema usa [distintos sufijos](https://github.com/activerecord-hackery/ransack#search-matchers) para indicar distintos tipos de búsqueda. Además, nos permite hacer búsquedas con respecto a [atributos de asociaciones](https://github.com/activerecord-hackery/ransack#associations).
+
+Por ejemplo, si queremos buscar blogs por nombre de usuario:
+
+```
+filter :user_name_cont
+```
+
+Aquí `_cont` indica que se entregarán los resultados que contengan el valor dado. Podríamos haber usado `_eq` si quisieramos un match perfecto, por ejemplo.
+
+
 ### Recursos útiles
 
 - [Active Admin Docs](https://activeadmin.info/documentation.html)

--- a/stack/ruby/rails/shrine.md
+++ b/stack/ruby/rails/shrine.md
@@ -167,6 +167,7 @@ include ProfilePictureUploader::Attachment(:profile_picture)
 - [Direct S3 Upload](https://github.com/shrinerb/shrine/wiki/Adding-Direct-S3-Uploads) / [Direct App Upload](https://github.com/shrinerb/shrine/wiki/Adding-Direct-App-Uploads): ambos sirven para subir un archivo antes de que se le haga submit a un form. La diferencia radica en que el de S3 lo sube directamente a AWS, mientras que el otro lo sube a un `upload_endpoint` de la aplicación. Para ambientes que no tienen un bucket S3 (como `development`, en que se guardan los archivos en el filesystem) habría que usar Direct App Upload
 - [Demo Direct Upload + Vue](https://drive.google.com/file/d/1fwrZ1tLZa_xeSp2j57iKFgjNlgDxXAM9/view?usp=sharing): presentación al equipo de Platanus para introducir Shrine. Se arma un componente Vue para manejar el Direct Upload que puede ser usado dentro de un form de Rails
 - [Testing](https://shrinerb.com/docs/testing): en la sección de [Test data](https://shrinerb.com/docs/testing#test-data) dan un ejemplo de un helper que puede ser usado en las factories. En la sección de [Acceptance tests](https://shrinerb.com/docs/testing#acceptance-tests) dan un ejemplo de como agregar un archivo como parámetro en tests de controladores usando `Rack::Test::UploadedFile`
+- [Agregar link de download en ActiveAdmin](activeadmin.md#shrine-download)
 
 #### Recursos útiles para plataneros
 - [Implementación Direct Upload](https://github.com/platanus/gret/pull/22): PR implementando Direct Upload para ser usado en ActiveAdmin


### PR DESCRIPTION
Se agregan dos secciones a la página de active admin:
- Como agregar link de download de un archivo. Se agrega link a la sección de Shrine, y en la sección de shrine se linkea a esta sección
- Filtros custom con ransack. Links a los docs, a los matches y a la sección de asociaciones. Se pone ejemplo simple