### PR TITLE
fix(): add missing s3 links

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -55,6 +55,7 @@
   * [Apple App Store](setup/proyectos/apple-app-store.md)
   * [Google Play](setup/proyectos/google-play.md)
   * [Expo](setup/proyectos/expo.md)
+  * [S3](setup/proyectos/S3.md)
 
 ## Herramientas
 * [Diseño/UX](tools/design/README.md)

--- a/setup/proyectos/README.md
+++ b/setup/proyectos/README.md
@@ -7,3 +7,4 @@
 * [Apple App Store](apple-app-store.md)
 * [Google Play](google-play.md)
 * [Expo](expo.md)
+* [S3](S3.md)


### PR DESCRIPTION
En el pr anterior #183 se agregó la sección de S3 a la parte de setup, pero faltó agregarlo al summary para que aparezca en el sidebar y en el readme de la sección