### PR TITLE
feat(tecnologias/ruby): update ruby installation instructions

### DIFF
--- a/setup/local/tecnologias/ruby.md
+++ b/setup/local/tecnologias/ruby.md
@@ -4,36 +4,75 @@ Para nuestros desarrollos en ruby utilizamos el manejador de versiones [rbenv](h
 
 ### OSX
 
+#### Previo a la instalación
+Antes de empezar con esta instalación tienes que revisar si tienes `rvm` instalado y quitarlo de tu computador.
+
+Para esto ejecuta:
 ```bash
-# Instala rbenv y ruby-build
-brew install rbenv ruby-build
+  rvm
+  ```
+y si dice que no existe, tu computador está listo para la instalación, y si aparece algo tienes que desinstalarlo con
+```bash
+  rvm implode
+
+  gem uninstall rvm
+  ```
+  Finalente, revisa tus archivos `.bash_profile` o `.zshrc` y comprueba que no quedan lineas relacionadas con `rvm`.
+
+#### Instalación
+```bash
+# Instala rbenv
+brew install rbenv
 
 # Instala plugins
 brew install rbenv-vars rbenv-aliases rbenv-default-gems
 ```
 
-Luego debes cargar rbenv en tu shell para que puedas acceder a las diferentes versiones. Para esto debes agregar la siguiente linea en tu `.bash_profile` o `.zshrc` dependiendo del shell que uses.
+Luego debes cargar rbenv en tu shell para que puedas acceder a las diferentes versiones. Para esto debes agregar la siguiente linea en tu `.bash_profile` o `.zshrc` dependiendo del shell que uses. Hay dos formas de hacerlo:
+
+1. Ejecutar el siguiente, que agrega automáticamente la línea necesaria:
+  * Si usas `.bash_profile`
+  ```bash
+  echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
+  ```
+  * Si usas `.zshrc`
+  ```bash
+  echo 'eval "$(rbenv init -)"' >> ~/.zshrc
+  ```
+
+2. Abrir  `.bash_profile` o `.zshrc` y agregar la linea en el archivo usando el editor de preferencia:
 
 ```bash
 eval "$(rbenv init -)"
 ```
 
-#### Instalando versiones de ruby
-
-Para instalar nuevas versiones de ruby puedes usar el plugin [ruby-build](https://github.com/rbenv/ruby-build)
+Te sugerimos, reiniciar la shell para que se apliquen los cambios. Para comprobar que tenemos `rbenv` instalado correctamente, escribe en tu consola la siguiente linea:
 
 ```bash
-# Listar todos las versiones disponibles para instalar
+rbenv
+```
+
+Debiera aparecer la versión de rbenv instalada y los comandos que hay para ejecutar.
+
+#### Posibles errores
+Un posible error al instalar `rbenv` es no tener bien configurado el PATH de la shell.
+
+
+#### Instalando versiones de ruby
+
+Para instalar nuevas versiones de ruby puedes usar el plugin [ruby-build](https://github.com/rbenv/ruby-build) o usar los siguientes comandos:
+
+```bash
+# Listar todos las versiones de ruby disponibles para instalar
 rbenv install --list
 
-# Instalar una version en particular
+# Instalar una version de ruby en particular
 rbenv install 2.4.1
-
-# Actualizar las versiones de ruby disponibles para instalar
-brew upgrade ruby-build
 ```
 
 > **Recomendación**: Define alguna version de ruby que quieras para tener como global haciendo `rbenv global 2.4.1`  De esta manera no estarás usando la version de ruby que trae el sistema operativo. Esto hace que sea más seguro ya que no necesitas usar `sudo` para instalar gemas.
+
+> **Warning**: Si no puedes usar `rbenv` o instalar gemas sin sudo, es muy probable que hayas dado los permisos equivocados en algún paso de la instalación. Esto no es seguro, por lo tanto te recomendamos eliminar todo y volver a hacer los pasos sin dar permisos de super usuario.
 
 > **TIP**: Las versiones de ruby quedan instaladas en `$HOME/.rbenv/versions`
 
@@ -80,8 +119,6 @@ rbenv alias --auto
 git clone https://github.com/rbenv/rbenv-default-gems.git $(rbenv root)/plugins/rbenv-default-gems
 
 ```
-
-
 
 #### Instalando versiones de ruby
 


### PR DESCRIPTION
- Se agrega como paso previo a la instalacion de ruby con rvm, sacar todo lo relacionado a este manager porque queda la escoba al tener ambos.
- Se dan opciones de como agregar el init a la shell
- Se agrega una pista de un posible error (bien recurrente) de tener mal configurado el PATH (creo que deberiamos tener una seccion explicando qué es el PATH en el mac y cómo tenerlo bien configurado, pero eso lo dejamos para otro PR).
- Sacamos lo instalar versiones de ruby con ruby-build y dejamos solo las instrucciones para hacerlo con rbenv. De todas formas dejamos el link a ruby-build por si alguien quiere usar ese plugin para instalar sus versiones de ruby.
- Pusimos el warning de instalar cosas con sudo. 