### PR TITLE
Setup improvements

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -57,6 +57,7 @@
     * [Node](setup/local/tecnologias/node.md)
     * [Docker](setup/local/tecnologias/docker.md)
 * [Proyectos](setup/proyectos/README.md)
+  * [Getting Started](setup/proyectos/getting-started.md)
   * [Heroku](setup/proyectos/heroku.md)
   * [Rails](setup/proyectos/rails.md)
   * [Integración Continua](setup/proyectos/continuous-integration.md)

--- a/setup/local/herramientas/ide/visual-studio-code.md
+++ b/setup/local/herramientas/ide/visual-studio-code.md
@@ -2,17 +2,41 @@
 
 Poco a poco Visual Studio Code ha superado a Sublime como el editor de texto más usado en Platanus.
 
-### Extensiones útiles
+### Extensiones
 
-- Ruby
-- Ruby Solargraph
-- ruby-rubocop
-- Vetur
-- Git Blame
-- ESLint
-- stylelint
-- Trailing Spaces
-- Project Manager
+#### Relacionadas al stack
+
+- [Ruby](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby)
+- [Ruby Solargraph](https://marketplace.visualstudio.com/items?itemName=castwide.solargraph)
+- [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur)
+- [Jest](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest)
+- [MJML](https://marketplace.visualstudio.com/items?itemName=attilabuti.vscode-mjml)
+- [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig): los proyectos vienen con un `.editorconfig` que nos ayuda a tener algunas configuraciones básicas consistentes. Este plugin se encarga de leerlo y aplicar esas configuraciones a tu editor
+- [Tailwind Intellisense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss)
+- [Tailwind Docs](https://marketplace.visualstudio.com/items?itemName=austenc.tailwind-docs)
+- [Headwind](https://marketplace.visualstudio.com/items?itemName=heybourn.headwind) (VS Code): Estandariza el orden de las clases de Tailwind al guardar.
+  > Por defecto Headwind no detecta las clases que se agregan a helpers de rails en un `.erb` usando `class:`. Para permitir esto se puede editar [la configuración de la extensión](https://marketplace.visualstudio.com/items?itemName=heybourn.headwind#headwind.classregex) en el `settings.json` de VSCode y poner el siguiente regex en la sección de `html`:
+  >
+  >`\\bclass\\s*[=:]\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']`
+
+#### Auxiliares
+
+- [Git Lens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
+- [Trailing Spaces](https://marketplace.visualstudio.com/items?itemName=shardulm94.trailing-spaces)
+- [Project Manager](https://marketplace.visualstudio.com/items?itemName=alefragnani.project-manager)
+- [Liveshare](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare-pack)
+- [Error Lens](https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens)
+- [Highlight Matching Tag](https://marketplace.visualstudio.com/items?itemName=vincaslt.highlight-matching-tag)
+- [Color Highlight](https://marketplace.visualstudio.com/items?itemName=naumovs.color-highlight)
+- [DotENV](https://marketplace.visualstudio.com/items?itemName=mikestead.dotenv)
+- [file-icons](https://marketplace.visualstudio.com/items?itemName=file-icons.file-icons)
+- [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one)
+- [Rainbow CSV](https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv)
+- [indent-rainbow](https://marketplace.visualstudio.com/items?itemName=oderwat.indent-rainbow)
+- [Open in Github](https://marketplace.visualstudio.com/items?itemName=sysoev.vscode-open-in-github)
+- [String Manipulation](https://marketplace.visualstudio.com/items?itemName=marclipovsky.string-manipulation)
+
+Si no lo has hecho todavía, revisa [la sección de linters](../linters.md).
 
 ### OSX
 #### Comandos más usados

--- a/setup/proyectos/README.md
+++ b/setup/proyectos/README.md
@@ -1,5 +1,6 @@
 ## Configuración de Proyectos
 
+* [Getting Started](getting-started.md)
 * [Heroku](heroku.md)
 * [Rails](rails.md)
 * [Integración Continua](continous-integration.md)

--- a/setup/proyectos/getting-started.md
+++ b/setup/proyectos/getting-started.md
@@ -50,6 +50,5 @@ Ahora, cada vez que quieras levantar o volver a trabajar en el proyecto, puede q
     {% hint style="info" %}
 Para chequear si el container efectivamente está prendido, puedes correr `docker container ls`. Si quieres una alternativa más "visual" puedes usar [Captain](https://getcaptain.co/) en OSX
     {% endhint %}
-1. Si hiciste un PR y te pidieron cambios, por lo general aplicamos esos cambios usando rebase. [En este post](https://plata.news/blog/manteniendo-la-historia-limpia-usando-git-rebase/) tenemos más info sobre rebase y cómo lo usamos para mantener la historia limpia
-1. Si los puntos anteriores no aplican y solo quieres volver a levantar el proyecto, basta con que repitas el paso 5 anterior (`bin/rails s`, 
-`bin/webpack-dev-server` y `bundle exec guard`), no debes correr el `bin/setup` de nuevo ni nada
+1. Si hiciste un PR y te pidieron cambios, por lo general aplicamos esos cambios usando rebase. [En este post de nuestro blog](https://plata.news/blog/manteniendo-la-historia-limpia-usando-git-rebase/) tenemos más info sobre rebase y cómo lo usamos para mantener la historia limpia. También revisa [este post](https://fle.github.io/git-tip-keep-your-branch-clean-with-fixup-and-autosquash.html) sobre fixup, otra herramienta del rebase que usamos para esto
+1. Si los puntos anteriores no aplican y solo quieres volver a levantar el proyecto, basta con que repitas el paso 5 anterior (`bin/rails s`, `bin/webpack-dev-server` y `bundle exec guard`), no debes correr el `bin/setup` de nuevo ni nada

--- a/setup/proyectos/getting-started.md
+++ b/setup/proyectos/getting-started.md
@@ -1,0 +1,41 @@
+## Getting started
+
+> Soy nuev@ y ya tengo asignado mi primer pitch! Qué tengo que hacer para levantar el proyecto y tener todo listo para ponerme a programar?
+
+Esto es lo que queremos responder con esta sección:
+
+1. Asegúrate de haber revisado [la sección de setup local](../local/README.md) y que tengas andando tu ambiente con todo instalado (node, ruby, docker, plugins de tu editor, etc).
+1. Clona el repositorio y muevete a la nueva carpeta:
+    ```
+    git clone https://github.com/platanus/<project-name>.git
+    cd project-name
+    ```
+1. Corre `bin/setup`. Esto te deja instaladas las gemas y paquetes que necesite el paquete, además de correr el setup de la base de datos. Puedes revisar el archivo para ver qué exactamente se está corriendo
+    {% hint style="info" %}
+A veces puede salir el error `Error: remote staging not found in git remotes` después de correr `bin/setup`. Si te aparece, probablemente es porque no tienes acceso al heroku del proyecto. Pídele acceso al encargado del proyecto y cuando lo tengas corre `bin/setup_heroku` para reintentar el paso que falló
+    {% endhint %}
+1. Para no empezar de 0 con una base de datos vacía, los proyectos tienen un `Makefile` con un par de comandos útiles para traernos datos de staging:
+    - Puedes correr `make backup-staging` para generar un nuevo backup en la base de datos de staging. Esto nos asegura que tengamos los datos más actualizados de staging
+    - `make restore-from-staging` toma el último backup de staging y lo copia en tu base de datos local
+1. Si todo salió bien, con esto deberías estar listo para correr el proyecto. Corre los siguientes comandos en paralelo en pestañas separadas:
+    - `bin/rails s`: levanta el servidor. Si vas a `localhost:3000` en el navegador verías la página
+    - `bin/webpack-dev-server`: permite que cada vez que se guarde un archivo js/vue, se recargue la página automáticamente
+    - `bundle exec guard`: cada vez que guardas un archivo ruby se ejecutan los tests correspondientes a ese archivo. Alternativamente, puedes correr todos los tests de manera manual usando `bin/rspec`
+        {% hint style="info" %}
+Si quieres correr un `it`, `context` o `describe` en particular, ignorando otros archivos y los demás ejemplos en el mismo archivo, puedes agregar una `f` al comienzo de este. Esto bunciona tanto para `guard` como para `rspec`.
+
+Esto es solo posible gracias a [filter_run_when_matching](https://relishapp.com/rspec/rspec-core/v/3-6/docs/filtering/filter-run-when-matching), por lo que debe estar configurado en el proyecto para poder usarlo
+        {% endhint %}
+    - `bin/rails c`: abre la consola de rails. En ella puedes probar cosas, por ejemplo, buscar o crear records. Puedes correr cualquier código Ruby/Rails, llamar a modelos/jobs/clients definidos en el proyecto, etc. No es estrictamente necesario, pero puede ser muy útil
+
+Ahora, cada vez que quieras levantar o volver a trabajar en el proyecto, puede que tengas que hacer alguna de estas cosas:
+
+1. Si alguien agregó cambios nuevos a master, es bueno traerlos frecuentemente a tu rama, así se resuelven periódicamente los conflictos que puedan aparecer. Para esto, usa rebase. Corre **en tu rama** `git pull origin master` para traerte los últimos cambios, y luego `git rebase -i master`. Esto te mostrará los commits que has agregado en tu rama y que quedarían sobre los de master. Si se encuentra un conflicto, el rebase para en el commit que lo contiene y te deja corregirlo antes de indicarle que siga
+1. Si alguien más está trabajando en el proyecto, puede que se hayan agregado nuevas gemas o paquetes. Para eso tendrías que correr `bundle install` y/o `yarn install`
+1. Si alguien más está trabajando en el proyecto, puede que se hayan agregado nuevas migraciones. Para eso tendrías que correr `bundle exec rails db:migrate:with_data`. Si quieres saber por qué el `with_data` puedes ver la sección de [data migrate](/stack/ruby/rails/data_migrate.md)
+    {% hint style="info" %}
+Para chequear si el container efectivamente está prendido, puedes correr `docker container ls`. Si quieres una alternativa más "visual" puedes usar [Captain](https://getcaptain.co/) en OSX
+    {% endhint %}
+1. Si hiciste un PR y te pidieron cambios, por lo general aplicamos esos cambios usando rebase. [En este post](https://plata.news/blog/manteniendo-la-historia-limpia-usando-git-rebase/) tenemos más info sobre rebase y cómo lo usamos para mantener la historia limpia
+1. Si los puntos anteriores no aplican y solo quieres volver a levantar el proyecto, basta con que repitas el paso 5 anterior (`bin/rails s`, 
+`bin/webpack-dev-server` y `bundle exec guard`), no debes correr el `bin/setup` de nuevo ni nada

--- a/setup/proyectos/getting-started.md
+++ b/setup/proyectos/getting-started.md
@@ -28,6 +28,20 @@ Esto es solo posible gracias a [filter_run_when_matching](https://relishapp.com/
         {% endhint %}
     - `bin/rails c`: abre la consola de rails. En ella puedes probar cosas, por ejemplo, buscar o crear records. Puedes correr cualquier código Ruby/Rails, llamar a modelos/jobs/clients definidos en el proyecto, etc. No es estrictamente necesario, pero puede ser muy útil
 
+{% hint style="info" %}
+Es posible que haciendo el setup te encuentres con un error como el siguiente:
+> gyp verb 'which' failed Error: not found: python2
+
+Si te ocurre, puede que tengas `yarn` instalado con `brew`, y en ese caso no se le puede indicar que use `python2`. Para solucionarlo, puedes instalar yarn a través de `npm` corriendo lo siguiente:
+
+```
+npm config set python /usr/bin/python
+brew uninstall yarn
+npm install -g yarn
+nodenv rehash
+```
+{% endhint %}
+
 Ahora, cada vez que quieras levantar o volver a trabajar en el proyecto, puede que tengas que hacer alguna de estas cosas:
 
 1. Si alguien agregó cambios nuevos a master, es bueno traerlos frecuentemente a tu rama, así se resuelven periódicamente los conflictos que puedan aparecer. Para esto, usa rebase. Corre **en tu rama** `git pull origin master` para traerte los últimos cambios, y luego `git rebase -i master`. Esto te mostrará los commits que has agregado en tu rama y que quedarían sobre los de master. Si se encuentra un conflicto, el rebase para en el commit que lo contiene y te deja corregirlo antes de indicarle que siga

--- a/setup/proyectos/git.md
+++ b/setup/proyectos/git.md
@@ -64,4 +64,4 @@ This commit adds an asynchronous validation when typing on the field so the user
 
 ### Rebase
 
-Para ordenar un poco los commits, usamos fixups y rebase. Puedes leer sobre eso [acá](https://fle.github.io/git-tip-keep-your-branch-clean-with-fixup-and-autosquash.html).
+Para ordenar un poco los commits, usamos fixups y rebase. [En este post de nuestro blog](https://plata.news/blog/manteniendo-la-historia-limpia-usando-git-rebase/) puedes leer sobre rebase y cómo lo usamos para mantener la historia limpia. También revisa [este post](https://fle.github.io/git-tip-keep-your-branch-clean-with-fixup-and-autosquash.html) sobre fixup, otra herramienta del rebase que usamos para esto.


### PR DESCRIPTION
- Se cambia la sección de extensiones de VSCode. Se agregan/sacan/cambian varias extensiones y se agregan links
- Se agrega sección de Getting Started al setup de proyectos. Tiene los pasos de setup de la primera vez que se corre, y cosas en que fijarse/que hacer para veces siguientes que se quiera correr

### Dudas a los reviewers / Cosas en que fijarse
- De las extensiones saqué las de linters, ya que hay una página aparte dedicada a ellos. Puse un link a esa al final
- Dividí las extensiones en relacionadas al stack y auxiliares, para darle algo de orden. No se si es la mejor separación, abierto a sugerencias ahí también
- Para headwind copié y pegué lo que estaba en [tailwind](https://github.com/platanus/la-guia/blob/master/stack/css/tailwind.md#recursos-%C3%BAtiles)
- En la parte de git, hay un link para explicar rebase que no es el del post del platanews. Explica otra parte si, el fixup, que no está en nuestro post. Creo que si vamos a mencionar rebase en los dos lados, deberíamos mencionar el o los mismos recursos. Qué opinan, solo el post de platanus o ponemos ambos?