### PR TITLE
fix(project-getting-started): replace nested hints with hyphens

### DIFF
--- a/setup/proyectos/getting-started.md
+++ b/setup/proyectos/getting-started.md
@@ -11,9 +11,7 @@ Esto es lo que queremos responder con esta sección:
     cd project-name
     ```
 1. Corre `bin/setup`. Esto te deja instaladas las gemas y paquetes que necesite el paquete, además de correr el setup de la base de datos. Puedes revisar el archivo para ver qué exactamente se está corriendo
-    {% hint style="info" %}
-    A veces puede salir el error `Error: remote staging not found in git remotes` después de correr `bin/setup`. Si te aparece, probablemente es porque no tienes acceso al heroku del proyecto. Pídele acceso al encargado del proyecto y cuando lo tengas corre `bin/setup_heroku` para reintentar el paso que falló
-    {% endhint %}
+    - A veces puede salir el error `Error: remote staging not found in git remotes` después de correr `bin/setup`. Si te aparece, probablemente es porque no tienes acceso al heroku del proyecto. Pídele acceso al encargado del proyecto y cuando lo tengas corre `bin/setup_heroku` para reintentar el paso que falló
 1. Para no empezar de 0 con una base de datos vacía, los proyectos tienen un `Makefile` con un par de comandos útiles para traernos datos de staging:
     - Puedes correr `make backup-staging` para generar un nuevo backup en la base de datos de staging. Esto nos asegura que tengamos los datos más actualizados de staging
     - `make restore-from-staging` toma el último backup de staging y lo copia en tu base de datos local
@@ -21,11 +19,7 @@ Esto es lo que queremos responder con esta sección:
     - `bin/rails s`: levanta el servidor. Si vas a `localhost:3000` en el navegador verías la página
     - `bin/webpack-dev-server`: permite que cada vez que se guarde un archivo js/vue, se recargue la página automáticamente
     - `bundle exec guard`: cada vez que guardas un archivo ruby se ejecutan los tests correspondientes a ese archivo. Alternativamente, puedes correr todos los tests de manera manual usando `bin/rspec`
-        {% hint style="info" %}
-        Si quieres correr un `it`, `context` o `describe` en particular, ignorando otros archivos y los demás ejemplos en el mismo archivo, puedes agregar una `f` al comienzo de este. Esto bunciona tanto para `guard` como para `rspec`.
-
-        Esto es solo posible gracias a [filter_run_when_matching](https://relishapp.com/rspec/rspec-core/v/3-6/docs/filtering/filter-run-when-matching), por lo que debe estar configurado en el proyecto para poder usarlo
-        {% endhint %}
+        - Si quieres correr un `it`, `context` o `describe` en particular, ignorando otros archivos y los demás ejemplos en el mismo archivo, puedes agregar una `f` al comienzo de este. Esto bunciona tanto para `guard` como para `rspec`. Esto es solo posible gracias a [filter_run_when_matching](https://relishapp.com/rspec/rspec-core/v/3-6/docs/filtering/filter-run-when-matching), por lo que debe estar configurado en el proyecto para poder usarlo
     - `bin/rails c`: abre la consola de rails. En ella puedes probar cosas, por ejemplo, buscar o crear records. Puedes correr cualquier código Ruby/Rails, llamar a modelos/jobs/clients definidos en el proyecto, etc. No es estrictamente necesario, pero puede ser muy útil
 
 {% hint style="info" %}
@@ -47,8 +41,6 @@ Ahora, cada vez que quieras levantar o volver a trabajar en el proyecto, puede q
 1. Si alguien agregó cambios nuevos a master, es bueno traerlos frecuentemente a tu rama, así se resuelven periódicamente los conflictos que puedan aparecer. Para esto, usa rebase. Corre **en tu rama** `git pull origin master` para traerte los últimos cambios, y luego `git rebase -i master`. Esto te mostrará los commits que has agregado en tu rama y que quedarían sobre los de master. Si se encuentra un conflicto, el rebase para en el commit que lo contiene y te deja corregirlo antes de indicarle que siga
 1. Si alguien más está trabajando en el proyecto, puede que se hayan agregado nuevas gemas o paquetes. Para eso tendrías que correr `bundle install` y/o `yarn install`
 1. Si alguien más está trabajando en el proyecto, puede que se hayan agregado nuevas migraciones. Para eso tendrías que correr `bundle exec rails db:migrate:with_data`. Si quieres saber por qué el `with_data` puedes ver la sección de [data migrate](/stack/ruby/rails/data_migrate.md)
-    {% hint style="info" %}
-    Para chequear si el container efectivamente está prendido, puedes correr `docker container ls`. Si quieres una alternativa más "visual" puedes usar [Captain](https://getcaptain.co/) en OSX
-    {% endhint %}
+    - Para chequear si el container efectivamente está prendido, puedes correr `docker container ls`. Si quieres una alternativa más "visual" puedes usar [Captain](https://getcaptain.co/) en OSX
 1. Si hiciste un PR y te pidieron cambios, por lo general aplicamos esos cambios usando rebase. [En este post de nuestro blog](https://plata.news/blog/manteniendo-la-historia-limpia-usando-git-rebase/) tenemos más info sobre rebase y cómo lo usamos para mantener la historia limpia. También revisa [este post](https://fle.github.io/git-tip-keep-your-branch-clean-with-fixup-and-autosquash.html) sobre fixup, otra herramienta del rebase que usamos para esto
 1. Si los puntos anteriores no aplican y solo quieres volver a levantar el proyecto, basta con que repitas el paso 5 anterior (`bin/rails s`, `bin/webpack-dev-server` y `bundle exec guard`), no debes correr el `bin/setup` de nuevo ni nada


### PR DESCRIPTION
### Contexto

En #215 se agregó una sección de Getting Started del setup de un proyecto.

### Cambios

Por alguna razón, lo que se agregó se ve distinto en la guía a lo que se ve al levantar en local con `gitbook serve`. Específicamente, en la guía las hints no se ven anidadas e interfieran con la enumeración y estilo de los elementos siguientes de la lista:

![image](https://user-images.githubusercontent.com/12057523/143486033-76afef9e-66c8-4efc-8d3b-fe513a41ac31.png)
*El bin/rails c debería ser otro elemento de la lista, como el bundle exec guard*

En #216 se probó cambiando indentación, pero no funcionó, se sigue viendo mal. En este pr se reemplazan los hints anidados por guiones no más