### PR TITLE
feat(browser-node): update guide and add more details

### DIFF
--- a/deployment/browser-node.md
+++ b/deployment/browser-node.md
@@ -1,6 +1,12 @@
 ## Browser and Node (Open Source)
 
-Siempre que crees una nueva librería invierte tiempo en buscar un buen nombre (compartelo con el equipo)
+Siempre que crees una nueva librería invierte tiempo en buscar un buen nombre (compártelo con el equipo)
+
+### Crear el paquete
+
+Primero, [crea un repositorio en Platanus](https://github.com/organizations/platanus/repositories/new). Asegúrate de que sea público.
+
+Luego puedes crear el paquete con ```npm init```, el cual te preguntará algunos detalles del paquete, o crear manualmente un ```package.json```.
 
 ### `package.json`
 
@@ -18,19 +24,85 @@ En el archivo `package.json` debemos llenar al menos los siguientes campos.
   "devDependencies": {
     ...
   }
+}
 ```
+
+Puedes agregar como autor a Platanus y a ti como colaborador:
+
+```js
+"author": {
+    "name": "Platanus",
+    "url": "https://platan.us"
+  },
+"contributors": [
+  {
+    "name": "Tu nombre"
+  }
+],
+```
+
+### Dependencias 
+
+Al menos deberías instalar las siguientes dependencias:
+
+- ```jest```: Testing
+- ```eslint```: Linter. Puedes copiar las [reglas](https://github.com/platanus/potassium/blob/master/lib/potassium/assets/.eslintrc.json) que vienen en Potassium. Puede ser necesario eliminar las reglas relacionadas a Vue y Tailwind si no serán utilizados.
+- ```eslint-plugin-import```: Permite utilizar el linter para revisar sintaxis de import/export. 
+
+Opcionalmente, puedes instalar:
+- ```eslint-plugin-jest```: en caso de no instalarlo reemplazar ```jest/globals``` en ```env``` de ```.eslintrc.json``` por solo ```jest```.
+
+### ES6 vs CommonJS export sintaxis
+Si estamos desarrollando un paquete de Node (y no de web) debemos usar la sintaxis de CommonJS para imports/exports:
+
+```js
+// lib.js
+module.exports = {
+  funcionLib
+}
+```
+
+```js
+// otro.js
+const lib = require('./lib')
+```
+
+Se puede utilizar esta sintaxis manualmente o utilizar la sintaxis de ES6 y luego compilar con un bundle como webpack para que la librería quede en formato CommonJS.
+
+### Comandos de consola personalizados para funciones del paquete
+
+Para correr algún archivo con un comando personalizado se deben seguir los siguientes pasos:
+- Crear un archivo ```cli.js``` o una carpeta ```cli``` con archivos que queremos que se ejecuten.
+- Al principio de estos archivos colocar:
+```bash
+#!/usr/bin/env node
+```
+- En ```package.json``` agregar una sección de:
+```javascript
+"bin": {
+  "nombre-comando-cli": "archivo.js",
+  "nombre-comando-cli-2": "archivo2.js",
+}
+```
+
+Correr ```npm link``` (permite simular la instalación del paquete), reiniciar la terminal y probar corriendo alguno de los comandos creados. 
+Si se modifica alguno de los archivos javascript no es necesario volver a correr ```npm link```.
 
 ### Publicación
 
-Los paquetes deben ser publicados en [NPM](http://npmjs.com).
+Los paquetes deben ser publicados en [NPM](http://npmjs.com). Si no la tienes, deberás crearte una cuenta personal.
 
 #### NPM
 
-En NPM debes registrar el paquete y publicar directamente cada version. La primera vez nos va a pedir nuestras credenciales de npmjs
+Si no has iniciado sesión en tu cuenta desde tu terminal, corre:
+
+    npm login
+
+En NPM debes registrar el paquete y publicar directamente cada versión. 
 
     npm publish
 
-> **IMPORTANTE:** Las publicaremos con nuestro usuario personal pero debemos agregar como owner al usuario de [platanus](https://npmjs.com/~platanus).
+> **IMPORTANTE:** Las publicaremos con nuestro usuario personal pero debemos agregar como owner al usuario de [platanus](https://www.npmjs.com/~platanus-owner).
 
     # Agregar un owner a un package
-    npm owner add platanus <package-name>
+    npm owner add platanus-owner <package-name>


### PR DESCRIPTION
Se actualiza la guía sobre cómo publicar paquetes en NPM. 

También se agregan distintos detalles y secciones para tener en consideración cuando se crea un paquete, como la creación del repositorio, la definición del `package.json`, las dependencias necesarias, cómo crear comandos por consola y la sintaxis de exports. 

La guía anterior mencionaba que se debía dar acceso de owner al paquete al usuario de [Platanus](https://www.npmjs.com/org/platanus) pero eso no funciona. Se cambió por dar acceso de owner al usuario [Platanus-owner](https://www.npmjs.com/~platanus-owner), pero no sé si cumple la misma función.

