### PR TITLE
docs(readme): fix typo to contributors url

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Todos estamos invitados a aportar en la construcción de esta [Guía maestra](ht
 
 ### Credits
 
-Thank you [contributors](https://github.com/platanus/la-guía/graphs/contributors)!
+Thank you [contributors](https://github.com/platanus/la-guia/graphs/contributors)!
 
 <img src="http://platan.us/gravatar_with_text.png" alt="Platanus" width="250"/>
 


### PR DESCRIPTION
The url was not working, it was redirecting me to a github 404, because it had a tilde in the "the-guia" 🙄